### PR TITLE
fix(security): tighten upload and auth surface

### DIFF
--- a/env.example
+++ b/env.example
@@ -32,6 +32,7 @@ DATABASE_URL="postgresql://postgres:[YOUR-PASSWORD]@db.[YOUR-PROJECT-REF].supaba
 # NextAuth.js 配置
 NEXTAUTH_URL="http://localhost:3000"
 NEXTAUTH_SECRET="your_nextauth_secret_here_minimum_32_characters"
+NEXTAUTH_COOKIE_DOMAIN=""
 
 # Google OAuth 配置 (必需)
 # 获取地址: https://console.developers.google.com/

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
 import { r2Storage } from '@/lib/services/r2-storage'
+import { authOptions } from '@/lib/auth'
 
 // 支持的文件类型配置
 const SUPPORTED_TYPES = {
@@ -17,8 +19,24 @@ const SIZE_LIMITS = {
   document: 5
 }
 
+const MEDIA_TYPES = new Set(Object.keys(SUPPORTED_TYPES))
+
+function sanitizeSegment(value: string, fallback: string): string {
+  const normalized = value.trim().toLowerCase().replace(/[^a-z0-9-]/g, '-')
+  const collapsed = normalized.replace(/-+/g, '-').replace(/^-|-$/g, '')
+  return collapsed || fallback
+}
+
 export async function POST(request: NextRequest) {
   try {
+    const session = await getServerSession(authOptions)
+    if (!session?.user?.email) {
+      return NextResponse.json({
+        success: false,
+        error: '请先登录后再上传文件'
+      }, { status: 401 })
+    }
+
     // 检查R2是否启用
     if (process.env.NEXT_PUBLIC_ENABLE_R2 !== 'true') {
       return NextResponse.json({
@@ -29,8 +47,10 @@ export async function POST(request: NextRequest) {
 
     const formData = await request.formData()
     const file = formData.get('file') as File
-    const mediaType = formData.get('mediaType') as string || 'image'
-    const purpose = formData.get('purpose') as string || 'general' // 用途：character, music, video, general
+    const requestedMediaType = (formData.get('mediaType') as string) || 'image'
+    const requestedPurpose = (formData.get('purpose') as string) || 'general'
+    const mediaType = MEDIA_TYPES.has(requestedMediaType) ? requestedMediaType : 'image'
+    const purpose = sanitizeSegment(requestedPurpose, 'general')
 
     if (!file) {
       return NextResponse.json({
@@ -57,15 +77,6 @@ export async function POST(request: NextRequest) {
       }, { status: 400 })
     }
 
-    // 生成文件路径
-    const timestamp = Date.now()
-    const randomId = Math.random().toString(36).substring(2, 8)
-    const extension = file.name.split('.').pop()
-    const fileName = `${purpose}_${timestamp}_${randomId}.${extension}`
-    
-    // 根据用途和媒体类型生成路径
-    const filePath = `${mediaType}s/${purpose}/${fileName}`
-
     // 上传到R2
     const uploadResult = await r2Storage.uploadFile(file)
 
@@ -73,12 +84,10 @@ export async function POST(request: NextRequest) {
       success: true,
       data: {
         url: uploadResult,
-        key: filePath,
-        filename: fileName,
         size: file.size,
         contentType: file.type,
-        mediaType: mediaType,
-        purpose: purpose
+        mediaType,
+        purpose
       }
     })
 
@@ -101,4 +110,4 @@ export async function GET() {
     supportedTypes: SUPPORTED_TYPES,
     sizeLimits: SIZE_LIMITS
   })
-} 
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -10,6 +10,35 @@ import { User } from "@/lib/types/user"
 import { createClient } from '@supabase/supabase-js'
 
 const providers: any[] = []
+const isProduction = process.env.NODE_ENV === 'production'
+
+function getCookieDomain(): string | undefined {
+  if (!isProduction) {
+    return undefined
+  }
+
+  const explicitDomain = process.env.NEXTAUTH_COOKIE_DOMAIN?.trim()
+  if (explicitDomain) {
+    return explicitDomain
+  }
+
+  const siteUrl =
+    process.env.NEXTAUTH_URL ||
+    process.env.NEXT_PUBLIC_SITE_URL ||
+    process.env.NEXT_PUBLIC_WEB_URL
+
+  if (!siteUrl) {
+    return undefined
+  }
+
+  try {
+    return new URL(siteUrl).hostname
+  } catch {
+    return undefined
+  }
+}
+
+const cookieDomain = getCookieDomain()
 
 // Google Auth (如果配置了)
 if (
@@ -133,8 +162,8 @@ export const authOptions: NextAuthOptions = {
         httpOnly: true,
         sameSite: 'lax',        // 🔧 设置为lax而非strict，支持第三方登录
         path: '/',
-        secure: process.env.NODE_ENV === 'production',
-        domain: process.env.NODE_ENV === 'production' ? 'fluxkontext.space' : undefined, // 🌐 明确指定域名
+        secure: isProduction,
+        domain: cookieDomain,
       },
     },
     callbackUrl: {
@@ -142,8 +171,8 @@ export const authOptions: NextAuthOptions = {
       options: {
         sameSite: 'lax',        // 🔧 支持跨站点回调
         path: '/',
-        secure: process.env.NODE_ENV === 'production',
-        domain: process.env.NODE_ENV === 'production' ? 'fluxkontext.space' : undefined,
+        secure: isProduction,
+        domain: cookieDomain,
       },
     },
     csrfToken: {
@@ -152,8 +181,8 @@ export const authOptions: NextAuthOptions = {
         httpOnly: true,
         sameSite: 'lax',        // 🔧 支持CSRF保护但允许第三方登录
         path: '/',
-        secure: process.env.NODE_ENV === 'production',
-        domain: process.env.NODE_ENV === 'production' ? 'fluxkontext.space' : undefined,
+        secure: isProduction,
+        domain: cookieDomain,
       },
     },
     // 🔧 添加状态Cookie配置以支持Google One Tap
@@ -163,9 +192,9 @@ export const authOptions: NextAuthOptions = {
         httpOnly: true,
         sameSite: 'lax',
         path: '/',
-        secure: process.env.NODE_ENV === 'production',
+        secure: isProduction,
         maxAge: 900, // 15分钟
-        domain: process.env.NODE_ENV === 'production' ? 'fluxkontext.space' : undefined,
+        domain: cookieDomain,
       },
     },
     pkceCodeVerifier: {
@@ -174,9 +203,9 @@ export const authOptions: NextAuthOptions = {
         httpOnly: true,
         sameSite: 'lax',
         path: '/',
-        secure: process.env.NODE_ENV === 'production',
+        secure: isProduction,
         maxAge: 900, // 15分钟
-        domain: process.env.NODE_ENV === 'production' ? 'fluxkontext.space' : undefined,
+        domain: cookieDomain,
       },
     },
   },
@@ -343,4 +372,4 @@ async function detectUserLocation(): Promise<string> {
     console.error("地理位置检测失败:", error)
     return "US"
   }
-} 
+}

--- a/src/lib/services/r2-storage.ts
+++ b/src/lib/services/r2-storage.ts
@@ -8,6 +8,37 @@ interface R2Config {
   bucketName: string
 }
 
+const MIME_EXTENSION_MAP: Record<string, string> = {
+  'image/jpeg': 'jpg',
+  'image/png': 'png',
+  'image/webp': 'webp',
+  'image/gif': 'gif',
+  'video/mp4': 'mp4',
+  'video/webm': 'webm',
+  'video/quicktime': 'mov',
+  'audio/mpeg': 'mp3',
+  'audio/wav': 'wav',
+  'audio/ogg': 'ogg',
+  'audio/mp3': 'mp3',
+  'application/pdf': 'pdf',
+  'text/plain': 'txt',
+  'application/json': 'json'
+}
+
+function sanitizeMetadataValue(value: string, maxLength: number = 120): string {
+  return value.replace(/[^a-zA-Z0-9._ -]/g, '_').slice(0, maxLength)
+}
+
+function getSafeExtension(contentType: string, originalName?: string): string {
+  const mapped = MIME_EXTENSION_MAP[contentType]
+  if (mapped) {
+    return mapped
+  }
+
+  const fallback = originalName?.split('.').pop()?.toLowerCase()?.replace(/[^a-z0-9]/g, '')
+  return fallback || 'bin'
+}
+
 // 并发控制队列 - 增强版本
 class ConcurrencyQueue {
   private queue: Array<() => Promise<any>> = []
@@ -208,8 +239,8 @@ class R2StorageService {
     
     // 生成唯一文件名
     const timestamp = Date.now();
-    const randomString = Math.random().toString(36).substring(2, 15);
-    const extension = file.name.split('.').pop() || 'jpg';
+    const randomString = crypto.randomUUID().replace(/-/g, '').slice(0, 12);
+    const extension = getSafeExtension(file.type, file.name);
     const fileName = `flux-kontext-${timestamp}-${randomString}.${extension}`;
     
     console.log(`📋 Generated R2 filename: ${fileName}`);
@@ -223,7 +254,7 @@ class R2StorageService {
         ContentType: file.type || 'image/jpeg',
         CacheControl: 'public, max-age=31536000', // 1年缓存
         Metadata: {
-          'original-name': file.name,
+          'original-name': sanitizeMetadataValue(file.name),
           'upload-timestamp': timestamp.toString(),
           'source': 'user-upload'
         }
@@ -432,4 +463,4 @@ class R2StorageService {
 }
 
 // 导出单例实例
-export const r2Storage = new R2StorageService() 
+export const r2Storage = new R2StorageService()


### PR DESCRIPTION
## Summary
- require authentication for the dedicated upload API
- sanitize upload route inputs and avoid trusting user-provided filename extensions
- make NextAuth cookie domain derive from environment config instead of a hardcoded production host

## Testing
- ./node_modules/.bin/tsc --noEmit
- npm run build