### PR TITLE
fix(runtime): enforce API middleware and preserve response status

### DIFF
--- a/src/app/api/flux-kontext/route.ts
+++ b/src/app/api/flux-kontext/route.ts
@@ -998,6 +998,10 @@ export async function POST(request: NextRequest) {
       timeoutPromise
     ]);
 
+    if (result instanceof Response) {
+      return result;
+    }
+
     return NextResponse.json(result);
 
   } catch (error) {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,51 +1,54 @@
 import { NextRequest, NextResponse } from 'next/server'
 
-// 简单的内存速率限制器 (生产环境建议使用Redis)
+// Simple in-memory rate limiter. Use a shared backend like Redis in production.
 const rateLimitMap = new Map<string, { count: number; lastReset: number }>()
 
 function rateLimit(ip: string, limit: number = 10, windowMs: number = 60000): boolean {
   const now = Date.now()
   const windowStart = now - windowMs
-  
+
   const record = rateLimitMap.get(ip)
-  
+
   if (!record || record.lastReset < windowStart) {
     rateLimitMap.set(ip, { count: 1, lastReset: now })
     return true
   }
-  
+
   if (record.count >= limit) {
     return false
   }
-  
+
   record.count++
   return true
 }
 
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl
+  const hostname = request.nextUrl.hostname
   const debugRoutesEnabled =
     process.env.ENABLE_DEBUG_ROUTES === 'true' &&
     process.env.NODE_ENV !== 'production'
+  const isLocalHost =
+    hostname === 'localhost' ||
+    hostname === '127.0.0.1' ||
+    hostname === '::1'
 
   if (pathname.startsWith('/api/debug/') && !debugRoutesEnabled) {
     return NextResponse.json({ error: 'Not found' }, { status: 404 })
   }
-  
-  // 强制HTTPS重定向 (生产环境)
+
   if (process.env.NODE_ENV === 'production') {
     const proto = request.headers.get('x-forwarded-proto')
-    if (proto === 'http') {
-      return NextResponse.redirect(`https://fluxkontext.space${pathname}`, 301)
+    if (proto === 'http' && !isLocalHost) {
+      const httpsUrl = request.nextUrl.clone()
+      httpsUrl.protocol = 'https'
+      return NextResponse.redirect(httpsUrl, 301)
     }
   }
-  
-  // API v1 路由重写 - 将文档中的API端点映射到实际实现
+
   if (pathname.startsWith('/api/v1/')) {
-    let newPath = '/api/flux-kontext'
     let action = ''
-    
-    // 根据URL路径确定action类型
+
     if (pathname.includes('/text-to-image/pro')) {
       action = 'text-to-image-pro'
     } else if (pathname.includes('/text-to-image/max')) {
@@ -55,22 +58,19 @@ export function middleware(request: NextRequest) {
     } else if (pathname.includes('/image-edit/max')) {
       action = 'edit-image-max'
     }
-    
-    // 创建新的URL并添加action参数
+
     const url = request.nextUrl.clone()
-    url.pathname = newPath
-    
-    // 如果确定了action，添加到查询参数中
+    url.pathname = '/api/flux-kontext'
+
     if (action) {
       url.searchParams.set('action', action)
     }
-    
+
     return NextResponse.rewrite(url)
   }
-  
+
   const response = NextResponse.next()
-  
-  // 添加安全头
+
   response.headers.set('X-Frame-Options', 'DENY')
   response.headers.set('X-Content-Type-Options', 'nosniff')
   response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin')
@@ -79,64 +79,62 @@ export function middleware(request: NextRequest) {
     'Strict-Transport-Security',
     'max-age=31536000; includeSubDomains'
   )
-  
-  // 内容安全策略 - 修复Google OAuth和TrustedScript问题
+
   response.headers.set(
     'Content-Security-Policy',
     "default-src 'self'; " +
-    "script-src 'self' 'unsafe-inline' 'unsafe-eval' " +
-    "https://platform.twitter.com " +
-    "https://www.googletagmanager.com " +
-    "https://accounts.google.com " +
-    "https://apis.google.com " +
-    "https://www.gstatic.com " +
-    "https://gstatic.com " +
-    "https://challenges.cloudflare.com " +
-    "https://static.cloudflareinsights.com " +
-    "data: blob:; " +
-    "style-src 'self' 'unsafe-inline' " +
-    "https://fonts.googleapis.com " +
-    "https://accounts.google.com " +
-    "https://www.gstatic.com; " +
-    "font-src 'self' " +
-    "https://fonts.gstatic.com " +
-    "https://accounts.google.com " +
-    "data:; " +
-    "img-src 'self' data: https: blob:; " +
-    "connect-src 'self' https: " +
-    "https://accounts.google.com " +
-    "https://www.googleapis.com " +
-    "https://challenges.cloudflare.com " +
-    "wss: ws:; " +
-    "frame-src 'self' " +
-    "https://accounts.google.com " +
-    "https://www.google.com " +
-    "https://challenges.cloudflare.com; " +
-    "object-src 'none'; " +
-    "base-uri 'self'; " +
-    "form-action 'self' https:; " +
-    "frame-ancestors 'self';"
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval' " +
+      "https://platform.twitter.com " +
+      "https://www.googletagmanager.com " +
+      "https://accounts.google.com " +
+      "https://apis.google.com " +
+      "https://www.gstatic.com " +
+      "https://gstatic.com " +
+      "https://challenges.cloudflare.com " +
+      "https://static.cloudflareinsights.com " +
+      "data: blob:; " +
+      "style-src 'self' 'unsafe-inline' " +
+      "https://fonts.googleapis.com " +
+      "https://accounts.google.com " +
+      "https://www.gstatic.com; " +
+      "font-src 'self' " +
+      "https://fonts.gstatic.com " +
+      "https://accounts.google.com " +
+      "data:; " +
+      "img-src 'self' data: https: blob:; " +
+      "connect-src 'self' https: " +
+      "https://accounts.google.com " +
+      "https://www.googleapis.com " +
+      "https://challenges.cloudflare.com " +
+      "wss: ws:; " +
+      "frame-src 'self' " +
+      "https://accounts.google.com " +
+      "https://www.google.com " +
+      "https://challenges.cloudflare.com; " +
+      "object-src 'none'; " +
+      "base-uri 'self'; " +
+      "form-action 'self' https:; " +
+      "frame-ancestors 'self';"
   )
-  
-  // API路由速率限制
+
   if (request.nextUrl.pathname.startsWith('/api/')) {
     const forwarded = request.headers.get('x-forwarded-for')
-    const ip = forwarded ? forwarded.split(',')[0].trim() : 
-               request.headers.get('x-real-ip') ?? 
-               '127.0.0.1'
-    
-    // 不同API端点不同的限制
+    const ip =
+      forwarded
+        ? forwarded.split(',')[0].trim()
+        : request.headers.get('x-real-ip') ?? '127.0.0.1'
+
     let limit = 10
-    let windowMs = 60000 // 1分钟
-    
+    let windowMs = 60000
+
     if (request.nextUrl.pathname.includes('/auth/')) {
-      limit = 5 // 认证相关更严格
-      windowMs = 300000 // 5分钟
+      limit = 5
+      windowMs = 300000
     } else if (request.nextUrl.pathname.includes('/payment/')) {
-      limit = 3 // 支付相关最严格
-      windowMs = 600000 // 10分钟
+      limit = 3
+      windowMs = 600000
     }
-    
+
     if (!rateLimit(ip, limit, windowMs)) {
       return NextResponse.json(
         { error: 'Rate limit exceeded' },
@@ -144,13 +142,10 @@ export function middleware(request: NextRequest) {
       )
     }
   }
-  
+
   return response
 }
 
 export const config = {
-  matcher: [
-    // 暂时禁用middleware，只匹配API路由进行测试
-    '/api/(.*)',
-  ],
+  matcher: ['/api/:path*'],
 }


### PR DESCRIPTION
## Summary
- move the API middleware into  so Next.js actually loads it
- preserve existing  objects in  instead of wrapping them into  responses
- upgrade HTTP redirects to the current request host and avoid redirecting localhost traffic to production

## Testing
- npm run build
- local production smoke test with 
- verified  returns 404 in production mode
- verified unauthenticated  and  return 401