### PR TITLE
refactor(provider): add unified image generation adapters

### DIFF
--- a/env.example
+++ b/env.example
@@ -12,6 +12,20 @@
 # 获取地址: https://fal.ai/dashboard
 FAL_KEY="your_fal_api_key_here"
 
+# 图像生成 provider 选择
+# 可选值: fal | kie | wavespeed
+IMAGE_GENERATION_PROVIDER="fal"
+
+# KIE AI API密钥（仅在 IMAGE_GENERATION_PROVIDER=kie 时需要）
+KIE_API_KEY=""
+KIE_WEBHOOK_SIGNING_SECRET=""
+KIE_API_BASE_URL="https://api.kie.ai"
+
+# WaveSpeed API密钥（仅在 IMAGE_GENERATION_PROVIDER=wavespeed 时需要）
+WAVESPEED_API_KEY=""
+WAVESPEED_WEBHOOK_SECRET=""
+WAVESPEED_API_BASE_URL="https://api.wavespeed.ai/api/v3"
+
 # =============================================================================
 # 🗄️ 数据库配置 (必需)
 # =============================================================================

--- a/src/app/api/flux-kontext/route.ts
+++ b/src/app/api/flux-kontext/route.ts
@@ -5,6 +5,7 @@ import { authOptions } from '@/lib/auth';
 import { consumeCreditsForImageGeneration, checkUserCredits } from '@/lib/services/credits';
 import { prisma } from '@/lib/database';
 import { checkPromptSafety, checkImageSafety } from '@/lib/content-safety/safe-mode';
+import { isFluxKontextAction } from '@/lib/image-generation/utils';
 import {
   getClientIpFromHeaders,
   getRequiredCredits,
@@ -241,9 +242,16 @@ export async function POST(request: NextRequest) {
           seed: body.seed
         });
 
-        // 🔧 添加详细的FAL API调用日志
-        verboseLog('📡 ===== 开始FAL API调用 =====')
+        if (!isFluxKontextAction(body.action)) {
+          throw new Error(`Unsupported action: ${body.action}`);
+        }
+
+        const providerName = FluxKontextService.getProviderName()
+
+        // 🔧 添加详细的 provider 调用日志
+        verboseLog('📡 ===== 开始图像 provider 调用 =====')
         verboseLog('📋 Sanitized request parameters:', {
+          provider: providerName,
           action: body.action,
           promptLength: typeof body.prompt === 'string' ? body.prompt.length : 0,
           hasImageUrl: !!body.image_url,
@@ -256,146 +264,21 @@ export async function POST(request: NextRequest) {
           seed: body.seed
         })
 
-        // 根据action类型调用相应的API
-        switch (body.action) {
-          case 'text-to-image-pro':
-            console.log('🎨 调用 textToImagePro')
-            result = await FluxKontextService.textToImagePro({
-              prompt: body.prompt,
-              aspect_ratio: body.aspect_ratio,
-              guidance_scale: body.guidance_scale,
-              num_images: body.num_images,
-              safety_tolerance: body.safety_tolerance,
-              output_format: body.output_format,
-              seed: body.seed
-            });
-            break;
-          case 'text-to-image-max':
-            console.log('🎨 调用 textToImageMax')
-            result = await FluxKontextService.textToImageMax({
-              prompt: body.prompt,
-              aspect_ratio: body.aspect_ratio,
-              guidance_scale: body.guidance_scale,
-              num_images: body.num_images,
-              safety_tolerance: body.safety_tolerance,
-              output_format: body.output_format,
-              seed: body.seed
-            });
-            break;
-          case 'text-to-image-schnell':
-            console.log('🎨 调用 textToImageSchnell')
-            result = await FluxKontextService.textToImageSchnell({
-              prompt: body.prompt,
-              aspect_ratio: body.aspect_ratio,
-              guidance_scale: body.guidance_scale,
-              num_images: body.num_images,
-              safety_tolerance: body.safety_tolerance,
-              output_format: body.output_format,
-              seed: body.seed
-            });
-            break;
-          case 'text-to-image-dev':
-            console.log('🎨 调用 textToImageDev')
-            result = await FluxKontextService.textToImageDev({
-              prompt: body.prompt,
-              aspect_ratio: body.aspect_ratio,
-              guidance_scale: body.guidance_scale,
-              num_images: body.num_images,
-              safety_tolerance: body.safety_tolerance,
-              output_format: body.output_format,
-              seed: body.seed
-            });
-            break;
-          case 'text-to-image-realism':
-            console.log('🎨 调用 textToImageRealism')
-            result = await FluxKontextService.textToImageRealism({
-              prompt: body.prompt,
-              aspect_ratio: body.aspect_ratio,
-              guidance_scale: body.guidance_scale,
-              num_images: body.num_images,
-              safety_tolerance: body.safety_tolerance,
-              output_format: body.output_format,
-              seed: body.seed
-            });
-            break;
-          case 'text-to-image-anime':
-            console.log('🎨 调用 textToImageAnime')
-            result = await FluxKontextService.textToImageAnime({
-              prompt: body.prompt,
-              aspect_ratio: body.aspect_ratio,
-              guidance_scale: body.guidance_scale,
-              num_images: body.num_images,
-              safety_tolerance: body.safety_tolerance,
-              output_format: body.output_format,
-              seed: body.seed
-            });
-            break;
-          case 'edit-image-pro':
-            console.log('✏️ 调用 editImagePro')
-            if (!body.image_url) {
-              throw new Error('image_url is required for edit-image-pro action');
-            }
-            result = await FluxKontextService.editImagePro({
-              prompt: body.prompt,
-              image_url: body.image_url,
-              guidance_scale: body.guidance_scale,
-              num_images: body.num_images,
-              safety_tolerance: body.safety_tolerance,
-              output_format: body.output_format,
-              seed: body.seed
-            });
-            break;
-          case 'edit-image-max':
-            console.log('✏️ 调用 editImageMax')
-            if (!body.image_url) {
-              throw new Error('image_url is required for edit-image-max action');
-            }
-            result = await FluxKontextService.editImageMax({
-              prompt: body.prompt,
-              image_url: body.image_url,
-              guidance_scale: body.guidance_scale,
-              num_images: body.num_images,
-              safety_tolerance: body.safety_tolerance,
-              output_format: body.output_format,
-              seed: body.seed
-            });
-            break;
-          case 'edit-multi-image-pro':
-            console.log('✏️ 调用 editMultiImagePro')
-            if (!body.image_urls || !Array.isArray(body.image_urls)) {
-              throw new Error('image_urls array is required for edit-multi-image-pro action');
-            }
-            result = await FluxKontextService.editMultiImagePro({
-              prompt: body.prompt,
-              image_urls: body.image_urls,
-              guidance_scale: body.guidance_scale,
-              num_images: body.num_images,
-              safety_tolerance: body.safety_tolerance,
-              output_format: body.output_format,
-              seed: body.seed
-            });
-            break;
-          case 'edit-multi-image-max':
-            console.log('✏️ 调用 editMultiImageMax')
-            if (!body.image_urls || !Array.isArray(body.image_urls)) {
-              throw new Error('image_urls array is required for edit-multi-image-max action');
-            }
-            result = await FluxKontextService.editMultiImageMax({
-              prompt: body.prompt,
-              image_urls: body.image_urls,
-              guidance_scale: body.guidance_scale,
-              num_images: body.num_images,
-              safety_tolerance: body.safety_tolerance,
-              output_format: body.output_format,
-              seed: body.seed
-            });
-            break;
-          default:
-            throw new Error(`Unsupported action: ${body.action}`);
-        }
+        result = await FluxKontextService.generateAction(body.action, {
+          prompt: body.prompt,
+          image_url: body.image_url,
+          image_urls: body.image_urls,
+          aspect_ratio: body.aspect_ratio,
+          guidance_scale: body.guidance_scale,
+          num_images: body.num_images,
+          safety_tolerance: body.safety_tolerance,
+          output_format: body.output_format,
+          seed: body.seed,
+        });
 
-        console.log('📨 ===== FAL API响应接收 =====')
-        console.log('📊 FAL API原始响应分析:', {
+        console.log('📨 ===== Provider 响应接收 =====')
+        console.log('📊 Provider 原始响应分析:', {
+          provider: providerName,
           hasResult: !!result,
           resultType: typeof result,
           resultKeys: result ? Object.keys(result) : [],
@@ -407,15 +290,15 @@ export async function POST(request: NextRequest) {
 
         // 🔧 增强结果验证和错误处理
         if (!result) {
-          console.error('❌ FAL API返回空结果')
-          throw new Error('FAL API returned null or undefined result');
+          console.error('❌ Provider 返回空结果')
+          throw new Error('Image provider returned null or undefined result');
         }
 
         // 🔧 检查是否有错误信息（使用类型断言处理可能的错误字段）
         const resultWithError = result as any;
         if (resultWithError.error) {
-          console.error('❌ FAL API返回错误:', resultWithError.error)
-          throw new Error(`FAL API error: ${resultWithError.error}`);
+          console.error('❌ Provider 返回错误:', resultWithError.error)
+          throw new Error(`Provider error: ${resultWithError.error}`);
         }
 
         // 🔧 检查images字段的各种可能位置
@@ -456,7 +339,7 @@ export async function POST(request: NextRequest) {
           
           if (!foundImages) {
             // 🔧 增强错误信息，特别针对图生图模式
-            let errorMessage = 'No images generated - FAL API returned empty or invalid images array.';
+            let errorMessage = 'No images generated - provider returned empty or invalid images array.';
             
             if (body.image_url || body.image_urls) {
               errorMessage += ' This may indicate an issue with image editing parameters or input image format.';
@@ -465,7 +348,7 @@ export async function POST(request: NextRequest) {
                 errorMessage += ` Note: aspect_ratio (${body.aspect_ratio}) in image editing mode may cause conflicts.`;
               }
             } else {
-              errorMessage += ' This may indicate a service issue, invalid parameters, or content policy violation.';
+              errorMessage += ' This may indicate a provider issue, invalid parameters, or content policy violation.';
             }
             
             console.error('❌ 未找到有效图像:', {
@@ -478,7 +361,7 @@ export async function POST(request: NextRequest) {
           }
         }
 
-        console.log(`✅ FAL API调用成功: ${result.images.length} 张图像生成完成`);
+        console.log(`✅ ${providerName} 调用成功: ${result.images.length} 张图像生成完成`);
         
         // 🔧 详细检查生成的图片信息
         if (process.env.ENABLE_VERBOSE_LOGS === 'true' && process.env.NODE_ENV !== 'production') {
@@ -739,6 +622,7 @@ export async function POST(request: NextRequest) {
 
         const responseData: any = {
           success: true,
+          provider: providerName,
           data: processedResult,
           credits_remaining: creditResult.user?.creditsAfter || 0,
           safety_check: {

--- a/src/lib/flux-kontext.ts
+++ b/src/lib/flux-kontext.ts
@@ -1,920 +1,252 @@
 import {
-  getFalQueueResult,
-  getFalQueueStatus,
-  submitFalQueue,
-  subscribeToFal,
-  uploadToFalStorage,
-} from "@/lib/fal-client";
-import { r2Storage } from "@/lib/services/r2-storage";
+  getImageGenerationProvider,
+  getImageGenerationProviderName,
+} from '@/lib/image-generation/providers'
+import {
+  FluxKontextAction,
+  FluxKontextGenerationRequest,
+  FluxKontextImage,
+  FluxKontextImageEditInput,
+  FluxKontextMultiImageInput,
+  FluxKontextResult,
+  FluxKontextTextToImageInput,
+  ImageGenerationProviderName,
+} from '@/lib/image-generation/types'
+import { r2Storage } from '@/lib/services/r2-storage'
 
-// 定义API端点常量 - 🔧 根据FAL API官方文档完全修复端点
-export const FLUX_ENDPOINTS = {
-  // 🔧 Kontext 图像编辑端点（image-to-image）- 根据官方文档修复
-  KONTEXT_PRO: "fal-ai/flux-pro/kontext",
-  KONTEXT_MAX: "fal-ai/flux-pro/kontext/max", 
-  
-  // 🔧 Kontext 多图像编辑端点 - 根据官方文档修复
-  KONTEXT_MAX_MULTI: "fal-ai/flux-pro/kontext/max/multi",
-  KONTEXT_PRO_MULTI: "fal-ai/flux-pro/kontext/multi",
-  
-  // 🔧 标准FLUX文生图端点 - 根据官方文档修复
-  FLUX_PRO_TEXT_TO_IMAGE: "fal-ai/flux-pro",
-  FLUX_MAX_TEXT_TO_IMAGE: "fal-ai/flux-pro/v1.1", // FLUX1.1 [pro]
-  
-  // 🔧 标准FLUX端点 - 根据官方文档修复
-  FLUX_SCHNELL: "fal-ai/flux/schnell",
-  FLUX_DEV: "fal-ai/flux/dev",
-  FLUX_GENERAL: "fal-ai/flux-general", // 通用FLUX端点，支持LoRA
-  FLUX_REALISM: "fal-ai/flux-lora", // 使用LoRA实现真实感
-  FLUX_ANIME: "fal-ai/flux-lora" // 使用LoRA实现动漫风格
-} as const;
+export type {
+  FluxKontextAction,
+  FluxKontextAspectRatio,
+  FluxKontextBaseInput,
+  FluxKontextGenerationRequest,
+  FluxKontextImage,
+  FluxKontextImageEditInput,
+  FluxKontextMultiImageInput,
+  FluxKontextOutputFormat,
+  FluxKontextResult,
+  FluxKontextSafetyTolerance,
+  FluxKontextTaskHandle,
+  FluxKontextTaskResult,
+  FluxKontextTaskState,
+  FluxKontextTextToImageInput,
+  ImageGenerationProviderName,
+} from '@/lib/image-generation/types'
 
-// 定义类型接口
-export interface FluxKontextBaseInput {
-  prompt: string;
-  seed?: number;
-  guidance_scale?: number;
-  sync_mode?: boolean;
-  num_images?: number;
-  safety_tolerance?: "1" | "2" | "3" | "4" | "5" | "6";
-  output_format?: "jpeg" | "png";
-}
-
-export interface FluxKontextImageEditInput extends FluxKontextBaseInput {
-  image_url: string;
-  aspect_ratio?: "21:9" | "16:9" | "4:3" | "3:2" | "1:1" | "2:3" | "3:4" | "9:16" | "9:21";
-}
-
-export interface FluxKontextMultiImageInput extends FluxKontextBaseInput {
-  image_urls: string[];
-  aspect_ratio?: "21:9" | "16:9" | "4:3" | "3:2" | "1:1" | "2:3" | "3:4" | "9:16" | "9:21";
-}
-
-export interface FluxKontextTextToImageInput extends FluxKontextBaseInput {
-  aspect_ratio?: "21:9" | "16:9" | "4:3" | "3:2" | "1:1" | "2:3" | "3:4" | "9:16" | "9:21";
-}
-
-export interface FluxKontextImage {
-  url: string;
-  width?: number;
-  height?: number;
-  content_type?: string;
-}
-
-export interface FluxKontextResult {
-  images: FluxKontextImage[];
-  timings?: any;
-  seed?: number;
-  has_nsfw_concepts?: boolean[];
-  prompt?: string;
-}
-
-// Flux Kontext API服务类
 export class FluxKontextService {
-  
-  /**
-   * Kontext [pro] - 图像编辑
-   * 快速迭代编辑，保持角色一致性
-   */
-  static async editImagePro(input: FluxKontextImageEditInput): Promise<FluxKontextResult> {
-    try {
-      // 🔧 根据API文档，移除不支持的aspect_ratio参数
-      const kontextInput = {
-        prompt: input.prompt,
-        image_url: input.image_url,
-        seed: input.seed,
-        guidance_scale: input.guidance_scale,
-        num_images: input.num_images,
-        safety_tolerance: input.safety_tolerance,
-        output_format: input.output_format
-        // ❌ 移除 aspect_ratio - Kontext API不支持此参数
-      };
+  static getProviderName(): ImageGenerationProviderName {
+    return getImageGenerationProviderName()
+  }
 
-      console.log(`🚀 Starting editImagePro with input:`, {
-        prompt: input.prompt?.substring(0, 100) + '...',
-        image_url: input.image_url?.substring(0, 50) + '...',
-        removed_aspect_ratio: input.aspect_ratio, // 记录被移除的参数
-        seed: input.seed,
-        guidance_scale: input.guidance_scale,
-        num_images: input.num_images,
-        safety_tolerance: input.safety_tolerance,
-        output_format: input.output_format,
-        endpoint: FLUX_ENDPOINTS.KONTEXT_PRO,
-        cleanedInput: JSON.stringify(kontextInput).substring(0, 300) + '...'
-      });
+  static async generateAction(
+    action: FluxKontextAction,
+    input: FluxKontextGenerationRequest
+  ): Promise<FluxKontextResult> {
+    const provider = getImageGenerationProvider()
+    const result = await provider.generate(action, input)
 
-      console.log(`📡 Calling fal.subscribe for endpoint: ${FLUX_ENDPOINTS.KONTEXT_PRO}`);
-      
-      const result = await subscribeToFal(FLUX_ENDPOINTS.KONTEXT_PRO, {
-        input: kontextInput, // 🔧 使用清理后的输入参数
-        logs: true,
-        onQueueUpdate: (update) => {
-          console.log(`📊 Queue update:`, {
-            status: update.status,
-            position: (update as any).queue_position,
-            logs: (update as any).logs?.map((log: any) => log.message).join(", ")
-          });
-          if (update.status === "IN_PROGRESS") {
-            console.log("Generation progress:", (update as any).logs?.map((log: any) => log.message).join("\n"));
-          }
-        },
-      });
-
-      console.log(`📋 FAL subscribe result:`, {
-        hasData: !!result.data,
-        dataType: typeof result.data,
-        hasImages: !!result.data?.images,
-        imagesCount: result.data?.images?.length || 0,
-        requestId: (result as any).requestId,
-        fullResultKeys: result ? Object.keys(result) : [],
-        dataKeys: result.data ? Object.keys(result.data) : [],
-        firstImageUrl: result.data?.images?.[0]?.url?.substring(0, 50) + '...' || 'N/A',
-        resultStringified: JSON.stringify(result).substring(0, 500) + '...'
-      });
-
-      if (!result.data) {
-        console.error('❌ FAL subscribe returned no data:', {
-          fullResult: result,
-          resultKeys: Object.keys(result),
-          resultStringified: JSON.stringify(result)
-        });
-        throw new Error('FAL API returned no data - this may indicate a service issue or invalid request');
-      }
-
-      // 🔍 检查data结构
-      if (!result.data.images) {
-        console.error('❌ FAL subscribe data has no images:', {
-          dataKeys: Object.keys(result.data),
-          dataStringified: JSON.stringify(result.data)
-        });
-        
-        // 🔍 尝试查找其他可能的图片字段
-        const possibleFields = ['image', 'output', 'result'];
-        for (const field of possibleFields) {
-          if ((result.data as any)[field]) {
-            console.log(`🔍 Found potential images in data.${field}:`, (result.data as any)[field]);
-            if (Array.isArray((result.data as any)[field])) {
-              (result.data as any).images = (result.data as any)[field];
-              break;
-            } else if (typeof (result.data as any)[field] === 'string') {
-              (result.data as any).images = [{ url: (result.data as any)[field] }];
-              break;
-            }
-          }
-        }
-        
-        if (!result.data.images) {
-          throw new Error('FAL API returned data without images field');
-        }
-      }
-
-      return result.data as FluxKontextResult;
-    } catch (error) {
-      console.error("❌ Flux Kontext Pro editing error:", {
-        error: error instanceof Error ? error.message : error,
-        stack: error instanceof Error ? error.stack : undefined,
-        input: {
-          prompt: input.prompt?.substring(0, 100) + '...',
-          image_url: input.image_url?.substring(0, 50) + '...'
-        }
-      });
-      throw error;
+    return {
+      ...result,
+      provider: provider.name,
     }
   }
 
-  /**
-   * Kontext [max] - 图像编辑
-   * 最高性能，改进的提示遵循和排版生成
-   */
-  static async editImageMax(input: FluxKontextImageEditInput): Promise<FluxKontextResult> {
-    try {
-      // 🔧 根据API文档，移除不支持的aspect_ratio参数
-      const kontextInput = {
-        prompt: input.prompt,
-        image_url: input.image_url,
-        seed: input.seed,
-        guidance_scale: input.guidance_scale,
-        num_images: input.num_images,
-        safety_tolerance: input.safety_tolerance,
-        output_format: input.output_format
-        // ❌ 移除 aspect_ratio - Kontext API不支持此参数
-      };
-
-      console.log(`🚀 Starting editImageMax with input:`, {
-        prompt: input.prompt?.substring(0, 100) + '...',
-        image_url: input.image_url?.substring(0, 50) + '...',
-        removed_aspect_ratio: input.aspect_ratio, // 记录被移除的参数
-        seed: input.seed,
-        guidance_scale: input.guidance_scale,
-        num_images: input.num_images,
-        safety_tolerance: input.safety_tolerance,
-        output_format: input.output_format,
-        endpoint: FLUX_ENDPOINTS.KONTEXT_MAX,
-        cleanedInput: JSON.stringify(kontextInput).substring(0, 300) + '...'
-      });
-
-      const result = await subscribeToFal(FLUX_ENDPOINTS.KONTEXT_MAX, {
-        input: kontextInput, // 🔧 使用清理后的输入参数
-        logs: true,
-        onQueueUpdate: (update) => {
-          if (update.status === "IN_PROGRESS") {
-            console.log("Generation progress:", update.logs?.map(log => log.message).join("\n"));
-          }
-        },
-      });
-      return result.data as FluxKontextResult;
-    } catch (error) {
-      console.error("❌ Flux Kontext Max editing error:", {
-        error: error instanceof Error ? error.message : error,
-        stack: error instanceof Error ? error.stack : undefined,
-        input: {
-          prompt: input.prompt?.substring(0, 100) + '...',
-          image_url: input.image_url?.substring(0, 50) + '...',
-          removed_aspect_ratio: input.aspect_ratio
-        }
-      });
-      throw error;
-    }
+  static async editImagePro(
+    input: FluxKontextImageEditInput
+  ): Promise<FluxKontextResult> {
+    return this.generateAction('edit-image-pro', input)
   }
 
-  /**
-   * Kontext [max] - 多图像编辑（实验性）
-   * 处理多个图像的编辑功能
-   */
-  static async editMultiImageMax(input: FluxKontextMultiImageInput): Promise<FluxKontextResult> {
-    try {
-      // 🔧 根据API文档，移除不支持的aspect_ratio参数
-      const kontextInput = {
-        prompt: input.prompt,
-        image_urls: input.image_urls,
-        seed: input.seed,
-        guidance_scale: input.guidance_scale,
-        num_images: input.num_images,
-        safety_tolerance: input.safety_tolerance,
-        output_format: input.output_format
-        // ❌ 移除 aspect_ratio - Kontext API不支持此参数
-      };
-
-      console.log(`🚀 Starting editMultiImageMax with input:`, {
-        prompt: input.prompt?.substring(0, 100) + '...',
-        image_urls_count: input.image_urls?.length || 0,
-        removed_aspect_ratio: input.aspect_ratio, // 记录被移除的参数
-        seed: input.seed,
-        guidance_scale: input.guidance_scale,
-        num_images: input.num_images,
-        safety_tolerance: input.safety_tolerance,
-        output_format: input.output_format,
-        endpoint: FLUX_ENDPOINTS.KONTEXT_MAX_MULTI,
-        cleanedInput: JSON.stringify(kontextInput).substring(0, 300) + '...'
-      });
-
-      const result = await subscribeToFal(FLUX_ENDPOINTS.KONTEXT_MAX_MULTI, {
-        input: kontextInput, // 🔧 使用清理后的输入参数
-        logs: true,
-        onQueueUpdate: (update) => {
-          if (update.status === "IN_PROGRESS") {
-            console.log("Generation progress:", update.logs?.map(log => log.message).join("\n"));
-          }
-        },
-      });
-      return result.data as FluxKontextResult;
-    } catch (error) {
-      console.error("❌ Flux Kontext Max multi-image editing error:", {
-        error: error instanceof Error ? error.message : error,
-        stack: error instanceof Error ? error.stack : undefined,
-        input: {
-          prompt: input.prompt?.substring(0, 100) + '...',
-          image_urls_count: input.image_urls?.length || 0,
-          removed_aspect_ratio: input.aspect_ratio
-        }
-      });
-      throw error;
-    }
+  static async editImageMax(
+    input: FluxKontextImageEditInput
+  ): Promise<FluxKontextResult> {
+    return this.generateAction('edit-image-max', input)
   }
 
-  /**
-   * Kontext [max] - 文本生成图像
-   * 最高性能的文本到图像生成
-   */
-  static async textToImageMax(input: FluxKontextTextToImageInput): Promise<FluxKontextResult> {
-    try {
-      // 🔧 转换参数格式：标准FLUX端点使用image_size而不是aspect_ratio
-      const fluxInput = {
-        prompt: input.prompt,
-        seed: input.seed,
-        guidance_scale: input.guidance_scale,
-        sync_mode: input.sync_mode,
-        num_images: input.num_images,
-        safety_tolerance: input.safety_tolerance,
-        output_format: input.output_format,
-        // 🔧 将aspect_ratio转换为image_size格式
-        image_size: this.convertAspectRatioToImageSize(input.aspect_ratio)
-      };
-
-      console.log(`🚀 Starting textToImageMax with converted input:`, {
-        prompt: input.prompt?.substring(0, 100) + '...',
-        original_aspect_ratio: input.aspect_ratio,
-        converted_image_size: fluxInput.image_size,
-        seed: input.seed,
-        guidance_scale: input.guidance_scale,
-        num_images: input.num_images,
-        safety_tolerance: input.safety_tolerance,
-        output_format: input.output_format,
-        endpoint: FLUX_ENDPOINTS.FLUX_MAX_TEXT_TO_IMAGE
-      });
-
-      console.log(`📡 Calling fal.subscribe for endpoint: ${FLUX_ENDPOINTS.FLUX_MAX_TEXT_TO_IMAGE}`);
-      
-      const result = await subscribeToFal(FLUX_ENDPOINTS.FLUX_MAX_TEXT_TO_IMAGE, {
-        input: fluxInput,
-        logs: true,
-        onQueueUpdate: (update) => {
-          console.log(`📊 Queue update:`, {
-            status: update.status,
-            position: (update as any).queue_position,
-            logs: (update as any).logs?.map((log: any) => log.message).join(", ")
-          });
-          if (update.status === "IN_PROGRESS") {
-            console.log("Generation progress:", (update as any).logs?.map((log: any) => log.message).join("\n"));
-          }
-        },
-      });
-
-      console.log(`📋 FAL subscribe result:`, {
-        hasData: !!result.data,
-        dataType: typeof result.data,
-        hasImages: !!result.data?.images,
-        imagesCount: result.data?.images?.length || 0,
-        requestId: (result as any).requestId,
-        fullResultKeys: result ? Object.keys(result) : [],
-        dataKeys: result.data ? Object.keys(result.data) : [],
-        firstImageUrl: result.data?.images?.[0]?.url?.substring(0, 50) + '...' || 'N/A',
-        resultStringified: JSON.stringify(result).substring(0, 500) + '...'
-      });
-
-      if (!result.data) {
-        console.error('❌ FAL subscribe returned no data:', {
-          fullResult: result,
-          resultKeys: Object.keys(result),
-          resultStringified: JSON.stringify(result)
-        });
-        throw new Error('FAL API returned no data - this may indicate a service issue or invalid request');
-      }
-
-      // 🔍 检查data结构
-      if (!result.data.images) {
-        console.error('❌ FAL subscribe data has no images:', {
-          dataKeys: Object.keys(result.data),
-          dataStringified: JSON.stringify(result.data)
-        });
-        
-        // 🔍 尝试查找其他可能的图片字段
-        const possibleFields = ['image', 'output', 'result'];
-        for (const field of possibleFields) {
-          if ((result.data as any)[field]) {
-            console.log(`🔍 Found potential images in data.${field}:`, (result.data as any)[field]);
-            if (Array.isArray((result.data as any)[field])) {
-              (result.data as any).images = (result.data as any)[field];
-              break;
-            } else if (typeof (result.data as any)[field] === 'string') {
-              (result.data as any).images = [{ url: (result.data as any)[field] }];
-              break;
-            }
-          }
-        }
-        
-        if (!result.data.images) {
-          throw new Error('FAL API returned data without images field');
-        }
-      }
-
-      return result.data as FluxKontextResult;
-    } catch (error) {
-      console.error("❌ Flux Max text-to-image error:", {
-        error: error instanceof Error ? error.message : error,
-        stack: error instanceof Error ? error.stack : undefined,
-        input: {
-          prompt: input.prompt?.substring(0, 100) + '...',
-          aspect_ratio: input.aspect_ratio
-        }
-      });
-      throw error;
-    }
+  static async editMultiImagePro(
+    input: FluxKontextMultiImageInput
+  ): Promise<FluxKontextResult> {
+    return this.generateAction('edit-multi-image-pro', input)
   }
 
-  /**
-   * Kontext [pro] - 多图像编辑（实验性）
-   * Pro版本的多图像处理功能
-   */
-  static async editMultiImagePro(input: FluxKontextMultiImageInput): Promise<FluxKontextResult> {
-    try {
-      // 🔧 根据API文档，移除不支持的aspect_ratio参数
-      const kontextInput = {
-        prompt: input.prompt,
-        image_urls: input.image_urls,
-        seed: input.seed,
-        guidance_scale: input.guidance_scale,
-        num_images: input.num_images,
-        safety_tolerance: input.safety_tolerance,
-        output_format: input.output_format
-        // ❌ 移除 aspect_ratio - Kontext API不支持此参数
-      };
-
-      console.log(`🚀 Starting editMultiImagePro with input:`, {
-        prompt: input.prompt?.substring(0, 100) + '...',
-        image_urls_count: input.image_urls?.length || 0,
-        removed_aspect_ratio: input.aspect_ratio, // 记录被移除的参数
-        seed: input.seed,
-        guidance_scale: input.guidance_scale,
-        num_images: input.num_images,
-        safety_tolerance: input.safety_tolerance,
-        output_format: input.output_format,
-        endpoint: FLUX_ENDPOINTS.KONTEXT_PRO_MULTI,
-        cleanedInput: JSON.stringify(kontextInput).substring(0, 300) + '...'
-      });
-
-      const result = await subscribeToFal(FLUX_ENDPOINTS.KONTEXT_PRO_MULTI, {
-        input: kontextInput, // 🔧 使用清理后的输入参数
-        logs: true,
-        onQueueUpdate: (update) => {
-          if (update.status === "IN_PROGRESS") {
-            console.log("Generation progress:", update.logs?.map(log => log.message).join("\n"));
-          }
-        },
-      });
-      return result.data as FluxKontextResult;
-    } catch (error) {
-      console.error("❌ Flux Kontext Pro multi-image editing error:", {
-        error: error instanceof Error ? error.message : error,
-        stack: error instanceof Error ? error.stack : undefined,
-        input: {
-          prompt: input.prompt?.substring(0, 100) + '...',
-          image_urls_count: input.image_urls?.length || 0,
-          removed_aspect_ratio: input.aspect_ratio
-        }
-      });
-      throw error;
-    }
+  static async editMultiImageMax(
+    input: FluxKontextMultiImageInput
+  ): Promise<FluxKontextResult> {
+    return this.generateAction('edit-multi-image-max', input)
   }
 
-  /**
-   * Kontext [pro] - 文本生成图像
-   * Pro版本的文本到图像生成
-   */
-  static async textToImagePro(input: FluxKontextTextToImageInput): Promise<FluxKontextResult> {
-    try {
-      // 🔧 转换参数格式：标准FLUX端点使用image_size而不是aspect_ratio
-      const fluxInput = {
-        prompt: input.prompt,
-        seed: input.seed,
-        guidance_scale: input.guidance_scale,
-        sync_mode: input.sync_mode,
-        num_images: input.num_images,
-        safety_tolerance: input.safety_tolerance,
-        output_format: input.output_format,
-        // 🔧 将aspect_ratio转换为image_size格式
-        image_size: this.convertAspectRatioToImageSize(input.aspect_ratio)
-      };
-
-      console.log(`🚀 Starting textToImagePro with converted input:`, {
-        prompt: input.prompt?.substring(0, 100) + '...',
-        original_aspect_ratio: input.aspect_ratio,
-        converted_image_size: fluxInput.image_size,
-        seed: input.seed,
-        guidance_scale: input.guidance_scale,
-        num_images: input.num_images,
-        safety_tolerance: input.safety_tolerance,
-        output_format: input.output_format,
-        endpoint: FLUX_ENDPOINTS.FLUX_PRO_TEXT_TO_IMAGE
-      });
-
-      console.log(`📡 Calling fal.subscribe for endpoint: ${FLUX_ENDPOINTS.FLUX_PRO_TEXT_TO_IMAGE}`);
-      
-      const result = await subscribeToFal(FLUX_ENDPOINTS.FLUX_PRO_TEXT_TO_IMAGE, {
-        input: fluxInput,
-        logs: true,
-        onQueueUpdate: (update) => {
-          console.log(`📊 Queue update:`, {
-            status: update.status,
-            position: (update as any).queue_position,
-            logs: (update as any).logs?.map((log: any) => log.message).join(", ")
-          });
-          if (update.status === "IN_PROGRESS") {
-            console.log("Generation progress:", (update as any).logs?.map((log: any) => log.message).join("\n"));
-          }
-        },
-      });
-
-      console.log(`📋 FAL subscribe result:`, {
-        hasData: !!result.data,
-        dataType: typeof result.data,
-        hasImages: !!result.data?.images,
-        imagesCount: result.data?.images?.length || 0,
-        requestId: (result as any).requestId,
-        fullResultKeys: result ? Object.keys(result) : [],
-        dataKeys: result.data ? Object.keys(result.data) : [],
-        firstImageUrl: result.data?.images?.[0]?.url?.substring(0, 50) + '...' || 'N/A',
-        resultStringified: JSON.stringify(result).substring(0, 500) + '...'
-      });
-
-      if (!result.data) {
-        console.error('❌ FAL subscribe returned no data:', {
-          fullResult: result,
-          resultKeys: Object.keys(result),
-          resultStringified: JSON.stringify(result)
-        });
-        throw new Error('FAL API returned no data - this may indicate a service issue or invalid request');
-      }
-
-      // 🔍 检查data结构
-      if (!result.data.images) {
-        console.error('❌ FAL subscribe data has no images:', {
-          dataKeys: Object.keys(result.data),
-          dataStringified: JSON.stringify(result.data)
-        });
-        
-        // 🔍 尝试查找其他可能的图片字段
-        const possibleFields = ['image', 'output', 'result'];
-        for (const field of possibleFields) {
-          if ((result.data as any)[field]) {
-            console.log(`🔍 Found potential images in data.${field}:`, (result.data as any)[field]);
-            if (Array.isArray((result.data as any)[field])) {
-              (result.data as any).images = (result.data as any)[field];
-              break;
-            } else if (typeof (result.data as any)[field] === 'string') {
-              (result.data as any).images = [{ url: (result.data as any)[field] }];
-              break;
-            }
-          }
-        }
-        
-        if (!result.data.images) {
-          throw new Error('FAL API returned data without images field');
-        }
-      }
-
-      return result.data as FluxKontextResult;
-    } catch (error) {
-      console.error("❌ Flux Pro text-to-image error:", {
-        error: error instanceof Error ? error.message : error,
-        stack: error instanceof Error ? error.stack : undefined,
-        input: {
-          prompt: input.prompt?.substring(0, 100) + '...',
-          aspect_ratio: input.aspect_ratio
-        }
-      });
-      throw error;
-    }
+  static async textToImagePro(
+    input: FluxKontextTextToImageInput
+  ): Promise<FluxKontextResult> {
+    return this.generateAction('text-to-image-pro', input)
   }
 
-  /**
-   * 上传文件到存储服务
-   * 🔧 同时上传到FAL和R2存储，优先使用FAL存储链接
-   */
+  static async textToImageMax(
+    input: FluxKontextTextToImageInput
+  ): Promise<FluxKontextResult> {
+    return this.generateAction('text-to-image-max', input)
+  }
+
+  static async textToImageSchnell(
+    input: FluxKontextTextToImageInput
+  ): Promise<FluxKontextResult> {
+    return this.generateAction('text-to-image-schnell', input)
+  }
+
+  static async textToImageDev(
+    input: FluxKontextTextToImageInput
+  ): Promise<FluxKontextResult> {
+    return this.generateAction('text-to-image-dev', input)
+  }
+
+  static async textToImageRealism(
+    input: FluxKontextTextToImageInput
+  ): Promise<FluxKontextResult> {
+    return this.generateAction('text-to-image-realism', input)
+  }
+
+  static async textToImageAnime(
+    input: FluxKontextTextToImageInput
+  ): Promise<FluxKontextResult> {
+    return this.generateAction('text-to-image-anime', input)
+  }
+
   static async uploadFile(file: File): Promise<string> {
-    try {
-      console.log("📤 Starting dual storage upload:", file.name);
-      
-      // 🔧 优先上传到FAL存储（确保API兼容性）
-      let falUrl: string | null = null;
-      let r2Url: string | null = null;
-      
+    const provider = getImageGenerationProvider()
+    let providerUrl: string | null = null
+    let r2Url: string | null = null
+
+    if (provider.uploadFile) {
       try {
-        console.log("📤 Uploading to FAL storage (primary):", file.name);
-        falUrl = await uploadToFalStorage(file);
-        console.log("✅ FAL upload successful:", falUrl);
-      } catch (falError) {
-        console.error("❌ FAL upload failed:", falError);
+        providerUrl = await provider.uploadFile(file)
+      } catch (error) {
+        console.warn(
+          `[${provider.name}] provider upload failed, falling back to R2 when available:`,
+          error
+        )
       }
-      
-      // 🔧 同时尝试上传到R2存储（备份和用户查看）
-      const isR2Enabled = process.env.NEXT_PUBLIC_ENABLE_R2 === "true";
-      const hasR2Config = process.env.R2_ACCOUNT_ID && 
-                         process.env.R2_ACCESS_KEY_ID && 
-                         process.env.R2_SECRET_ACCESS_KEY &&
-                         process.env.R2_BUCKET_NAME;
+    }
 
-      if (isR2Enabled && hasR2Config) {
-        try {
-          console.log("📤 Uploading to R2 storage (backup):", file.name);
-          r2Url = await r2Storage.uploadFile(file);
-          console.log("✅ R2 upload successful:", r2Url);
-        } catch (r2Error) {
-          console.warn("⚠️ R2 upload failed (non-critical):", r2Error);
-        }
-      } else {
-        console.log("ℹ️ R2 storage not configured, skipping R2 upload");
+    if (isR2Enabled()) {
+      try {
+        r2Url = await r2Storage.uploadFile(file)
+      } catch (error) {
+        console.warn('R2 upload failed during provider fallback:', error)
       }
-      
-      // 🔧 优先返回FAL URL，如果FAL失败则返回R2 URL
-      if (falUrl) {
-        console.log("🎯 Using FAL URL as primary:", falUrl);
-        if (r2Url) {
-          console.log("📋 R2 URL available as backup:", r2Url);
-        }
-        return falUrl;
-      } else if (r2Url) {
-        console.log("🎯 FAL failed, using R2 URL as fallback:", r2Url);
-        return r2Url;
-      } else {
-        throw new Error("Both FAL and R2 storage uploads failed");
-      }
-      
-    } catch (error) {
-      console.error("❌ Dual storage upload failed:", error);
-      throw error;
     }
+
+    if (providerUrl) {
+      return providerUrl
+    }
+
+    if (r2Url) {
+      return r2Url
+    }
+
+    throw new Error(
+      `No upload backend is available for provider "${provider.name}". Configure provider credentials or R2 storage.`
+    )
   }
 
-  /**
-   * 将AI生成的图片保存到R2存储
-   * @param imageUrl AI生成的图片URL
-   * @param prompt 生成提示词
-   */
-  static async saveGeneratedImageToR2(imageUrl: string, prompt: string): Promise<string> {
+  static async saveGeneratedImageToR2(
+    imageUrl: string,
+    prompt: string
+  ): Promise<string> {
+    if (!isR2Enabled()) {
+      return imageUrl
+    }
+
     try {
-      // 检查是否启用R2存储
-      const isR2Enabled = process.env.NEXT_PUBLIC_ENABLE_R2 === "true";
-      const hasR2Config = process.env.R2_ACCOUNT_ID && 
-                         process.env.R2_ACCESS_KEY_ID && 
-                         process.env.R2_SECRET_ACCESS_KEY &&
-                         process.env.R2_BUCKET_NAME;
-
-      if (!isR2Enabled || !hasR2Config) {
-        console.log("ℹ️ R2 storage not configured, returning original URL");
-        return imageUrl; // 如果R2未配置，返回原始URL
-      }
-
-      console.log("📤 Saving AI generated image to R2:", imageUrl);
-      
-      // 使用R2存储的uploadFromUrl方法
-      const result = await r2Storage.uploadFromUrl(imageUrl, prompt);
-      
-      console.log("✅ AI generated image saved to R2 successfully:", result);
-      return result;
-      
+      return await r2Storage.uploadFromUrl(imageUrl, prompt)
     } catch (error) {
-      console.error("❌ Failed to save AI generated image to R2:", error);
-      // 如果保存失败，返回原始URL
-      return imageUrl;
+      console.error('Failed to save generated image to R2:', error)
+      return imageUrl
     }
   }
 
-  /**
-   * 队列提交（用于长时间运行的请求）
-   */
-  static async submitToQueue(endpoint: string, input: any): Promise<{ request_id: string }> {
-    try {
-      const result = await submitFalQueue(endpoint, {
-        input,
-        webhookUrl: process.env.NEXT_PUBLIC_SITE_URL + "/api/webhooks/fal"
-      });
-      return result;
-    } catch (error) {
-      console.error("Queue submission error:", error);
-      throw error;
+  static async submitToQueue(
+    action: FluxKontextAction,
+    input: FluxKontextGenerationRequest
+  ): Promise<{ request_id: string }> {
+    const provider = getImageGenerationProvider()
+
+    if (!provider.submitTask) {
+      throw new Error(`${provider.name} does not support async task submission`)
     }
+
+    const webhookUrl = buildProviderWebhookUrl(provider.name)
+    const handle = await provider.submitTask(action, input, { webhookUrl })
+
+    return { request_id: handle.taskId }
   }
 
-  /**
-   * 检查队列状态
-   */
-  static async checkQueueStatus(endpoint: string, requestId: string): Promise<any> {
-    try {
-      const status = await getFalQueueStatus(endpoint, {
-        requestId,
-        logs: true,
-      });
-      return status;
-    } catch (error) {
-      console.error("Queue status check error:", error);
-      throw error;
+  static async checkQueueStatus(
+    action: FluxKontextAction,
+    requestId: string
+  ) {
+    const provider = getImageGenerationProvider()
+
+    if (!provider.getTaskResult) {
+      throw new Error(`${provider.name} does not support async task polling`)
     }
+
+    return provider.getTaskResult(action, requestId)
   }
 
-  /**
-   * 获取队列结果
-   */
-  static async getQueueResult(endpoint: string, requestId: string): Promise<FluxKontextResult> {
-    try {
-      const result = await getFalQueueResult(endpoint, {
-        requestId
-      });
-      return result.data as FluxKontextResult;
-    } catch (error) {
-      console.error("Queue result retrieval error:", error);
-      throw error;
+  static async getQueueResult(
+    action: FluxKontextAction,
+    requestId: string
+  ): Promise<FluxKontextResult> {
+    const task = await this.checkQueueStatus(action, requestId)
+
+    if (task.state !== 'completed' || !task.result) {
+      throw new Error(
+        task.error ||
+          `Task ${requestId} is still ${task.state} for provider ${task.provider}`
+      )
     }
+
+    return task.result
   }
 
-  /**
-   * FLUX.1 [schnell] - 文本生成图像
-   * 超快速生成，1-4步完成
-   */
-  static async textToImageSchnell(input: FluxKontextTextToImageInput): Promise<FluxKontextResult> {
-    try {
-      // 🔧 转换参数格式：FLUX Schnell端点使用image_size而不是aspect_ratio
-      const schnellInput = {
-        prompt: input.prompt,
-        seed: input.seed,
-        sync_mode: input.sync_mode,
-        num_images: input.num_images,
-        output_format: input.output_format,
-        // 🔧 将aspect_ratio转换为image_size格式
-        image_size: this.convertAspectRatioToImageSize(input.aspect_ratio),
-        // 🔧 Schnell模型使用较少的推理步骤
-        num_inference_steps: 4
-      };
+  static async verifyWebhook(
+    providerName: ImageGenerationProviderName,
+    rawBody: string,
+    headers: Headers | Record<string, string | undefined>
+  ) {
+    const provider = getImageGenerationProvider(providerName)
 
-      console.log(`🚀 Starting textToImageSchnell with converted input:`, {
-        prompt: input.prompt?.substring(0, 100) + '...',
-        original_aspect_ratio: input.aspect_ratio,
-        converted_image_size: schnellInput.image_size,
-        endpoint: FLUX_ENDPOINTS.FLUX_SCHNELL
-      });
-
-      const result = await subscribeToFal(FLUX_ENDPOINTS.FLUX_SCHNELL, {
-        input: schnellInput,
-        logs: true,
-        onQueueUpdate: (update) => {
-          if (update.status === "IN_PROGRESS") {
-            console.log("Generation progress:", update.logs?.map(log => log.message).join("\n"));
-          }
-        },
-      });
-      return result.data as FluxKontextResult;
-    } catch (error) {
-      console.error("Flux Schnell text-to-image error:", error);
-      throw error;
+    if (!provider.verifyWebhook) {
+      return false
     }
+
+    return provider.verifyWebhook(rawBody, headers)
+  }
+}
+
+function buildProviderWebhookUrl(providerName: ImageGenerationProviderName) {
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL?.trim()
+
+  if (!siteUrl) {
+    return undefined
   }
 
-  /**
-   * FLUX.1 [dev] - 文本生成图像
-   * 开发模型，平衡质量和速度
-   */
-  static async textToImageDev(input: FluxKontextTextToImageInput): Promise<FluxKontextResult> {
-    try {
-      // 🔧 转换参数格式：FLUX General端点使用image_size而不是aspect_ratio
-      const fluxInput = {
-        prompt: input.prompt,
-        seed: input.seed,
-        guidance_scale: input.guidance_scale,
-        sync_mode: input.sync_mode,
-        num_images: input.num_images,
-        safety_tolerance: input.safety_tolerance,
-        output_format: input.output_format,
-        // 🔧 将aspect_ratio转换为image_size格式
-        image_size: this.convertAspectRatioToImageSize(input.aspect_ratio)
-      };
+  return `${siteUrl}/api/webhooks/${providerName}`
+}
 
-      console.log(`🚀 Starting textToImageDev with converted input:`, {
-        prompt: input.prompt?.substring(0, 100) + '...',
-        original_aspect_ratio: input.aspect_ratio,
-        converted_image_size: fluxInput.image_size,
-        endpoint: FLUX_ENDPOINTS.FLUX_GENERAL
-      });
+function isR2Enabled() {
+  return Boolean(
+    process.env.NEXT_PUBLIC_ENABLE_R2 === 'true' &&
+      process.env.R2_ACCOUNT_ID &&
+      process.env.R2_ACCESS_KEY_ID &&
+      process.env.R2_SECRET_ACCESS_KEY &&
+      process.env.R2_BUCKET_NAME
+  )
+}
 
-      const result = await subscribeToFal(FLUX_ENDPOINTS.FLUX_GENERAL, {
-        input: fluxInput,
-        logs: true,
-        onQueueUpdate: (update) => {
-          if (update.status === "IN_PROGRESS") {
-            console.log("Generation progress:", update.logs?.map(log => log.message).join("\n"));
-          }
-        },
-      });
-      return result.data as FluxKontextResult;
-    } catch (error) {
-      console.error("Flux Dev text-to-image error:", error);
-      throw error;
-    }
-  }
-
-  /**
-   * FLUX Realism - 文本生成图像
-   * 照片级真实感图像生成
-   */
-  static async textToImageRealism(input: FluxKontextTextToImageInput): Promise<FluxKontextResult> {
-    try {
-      // 🔧 使用FLUX General端点和LoRA实现真实感风格
-      const realismInput = {
-        prompt: input.prompt,
-        seed: input.seed,
-        guidance_scale: input.guidance_scale,
-        sync_mode: input.sync_mode,
-        num_images: input.num_images,
-        safety_tolerance: input.safety_tolerance,
-        output_format: input.output_format,
-        // 🔧 将aspect_ratio转换为image_size格式
-        image_size: this.convertAspectRatioToImageSize(input.aspect_ratio),
-        // 🔧 使用LoRA实现真实感风格
-        loras: [
-          {
-            path: "https://huggingface.co/XLabs-AI/flux-RealismLora/resolve/main/lora.safetensors",
-            scale: 0.8
-          }
-        ]
-      };
-
-      console.log(`🚀 Starting textToImageRealism with LoRA:`, {
-        prompt: input.prompt?.substring(0, 100) + '...',
-        endpoint: FLUX_ENDPOINTS.FLUX_GENERAL,
-        loras: realismInput.loras
-      });
-      
-      const result = await subscribeToFal(FLUX_ENDPOINTS.FLUX_GENERAL, {
-        input: realismInput,
-        logs: true,
-        onQueueUpdate: (update) => {
-          if (update.status === "IN_PROGRESS") {
-            console.log("Generation progress:", update.logs?.map(log => log.message).join("\n"));
-          }
-        },
-      });
-      return result.data as FluxKontextResult;
-    } catch (error) {
-      console.error("Flux Realism text-to-image error:", error);
-      throw error;
-    }
-  }
-
-  /**
-   * FLUX Anime - 文本生成图像
-   * 动漫风格图像生成
-   */
-  static async textToImageAnime(input: FluxKontextTextToImageInput): Promise<FluxKontextResult> {
-    try {
-      // 🔧 使用FLUX General端点和LoRA实现动漫风格
-      const animeInput = {
-        prompt: input.prompt,
-        seed: input.seed,
-        guidance_scale: input.guidance_scale,
-        sync_mode: input.sync_mode,
-        num_images: input.num_images,
-        safety_tolerance: input.safety_tolerance,
-        output_format: input.output_format,
-        // 🔧 将aspect_ratio转换为image_size格式
-        image_size: this.convertAspectRatioToImageSize(input.aspect_ratio),
-        // 🔧 使用LoRA实现动漫风格
-        loras: [
-          {
-            path: "https://huggingface.co/Shakker-Labs/FLUX.1-dev-LoRA-AnimeStyle/resolve/main/FLUX-dev-lora-AnimeStyle.safetensors",
-            scale: 0.9
-          }
-        ]
-      };
-
-      console.log(`🚀 Starting textToImageAnime with LoRA:`, {
-        prompt: input.prompt?.substring(0, 100) + '...',
-        endpoint: FLUX_ENDPOINTS.FLUX_GENERAL,
-        loras: animeInput.loras
-      });
-      
-      const result = await subscribeToFal(FLUX_ENDPOINTS.FLUX_GENERAL, {
-        input: animeInput,
-        logs: true,
-        onQueueUpdate: (update) => {
-          if (update.status === "IN_PROGRESS") {
-            console.log("Generation progress:", update.logs?.map(log => log.message).join("\n"));
-          }
-        },
-      });
-      return result.data as FluxKontextResult;
-    } catch (error) {
-      console.error("Flux Anime text-to-image error:", error);
-      throw error;
-    }
-  }
-
-  /**
-   * 将aspect_ratio转换为image_size格式
-   */
-  static convertAspectRatioToImageSize(aspect_ratio?: string): "square_hd" | "square" | "portrait_4_3" | "portrait_16_9" | "landscape_4_3" | "landscape_16_9" | undefined {
-    if (!aspect_ratio) return "landscape_4_3"; // 默认值
-
-    // 将aspect_ratio转换为FAL API支持的image_size枚举
-    switch (aspect_ratio) {
-      case "1:1":
-        return "square_hd";
-      case "4:3":
-        return "landscape_4_3";
-      case "3:4":
-        return "portrait_4_3";
-      case "16:9":
-        return "landscape_16_9";
-      case "9:16":
-        return "portrait_16_9";
-      case "21:9":
-        return "landscape_16_9"; // 21:9映射到16:9，因为FAL不支持21:9
-      case "9:21":
-        return "portrait_16_9"; // 9:21映射到9:16，因为FAL不支持9:21
-      case "3:2":
-        return "landscape_4_3"; // 3:2映射到4:3
-      case "2:3":
-        return "portrait_4_3"; // 2:3映射到3:4
-      default:
-        return "landscape_4_3"; // 默认横向4:3
-    }
-  }
+export function getBestImageUrl(image: FluxKontextImage) {
+  return (
+    (image.r2_url as string | undefined) ||
+    (image.fal_url as string | undefined) ||
+    image.url
+  )
 }

--- a/src/lib/image-generation/providers/fal-provider.ts
+++ b/src/lib/image-generation/providers/fal-provider.ts
@@ -1,0 +1,267 @@
+import {
+  getFalQueueResult,
+  getFalQueueStatus,
+  submitFalQueue,
+  subscribeToFal,
+  uploadToFalStorage,
+} from '@/lib/fal-client'
+import {
+  FluxKontextAction,
+  FluxKontextGenerationRequest,
+  FluxKontextProvider,
+  FluxKontextResult,
+  FluxKontextTaskHandle,
+  FluxKontextTaskResult,
+  FluxKontextTaskState,
+} from '@/lib/image-generation/types'
+import {
+  aspectRatioToFalImageSize,
+  assertMultiImageInput,
+  assertSingleImageInput,
+  normalizeGenerationResult,
+} from '@/lib/image-generation/utils'
+
+type FalActionConfig = {
+  endpoint: string
+  buildInput: (
+    input: FluxKontextGenerationRequest
+  ) => Record<string, unknown>
+}
+
+const FAL_ENDPOINTS = {
+  KONTEXT_PRO: 'fal-ai/flux-pro/kontext',
+  KONTEXT_MAX: 'fal-ai/flux-pro/kontext/max',
+  KONTEXT_PRO_MULTI: 'fal-ai/flux-pro/kontext/multi',
+  KONTEXT_MAX_MULTI: 'fal-ai/flux-pro/kontext/max/multi',
+  FLUX_PRO_TEXT_TO_IMAGE: 'fal-ai/flux-pro',
+  FLUX_MAX_TEXT_TO_IMAGE: 'fal-ai/flux-pro/v1.1',
+  FLUX_SCHNELL: 'fal-ai/flux/schnell',
+  FLUX_DEV: 'fal-ai/flux/dev',
+  FLUX_GENERAL: 'fal-ai/flux-general',
+} as const
+
+const FAL_ACTIONS: Record<FluxKontextAction, FalActionConfig> = {
+  'text-to-image-pro': {
+    endpoint: FAL_ENDPOINTS.FLUX_PRO_TEXT_TO_IMAGE,
+    buildInput: (input) => buildFalTextToImageInput(input),
+  },
+  'text-to-image-max': {
+    endpoint: FAL_ENDPOINTS.FLUX_MAX_TEXT_TO_IMAGE,
+    buildInput: (input) => buildFalTextToImageInput(input),
+  },
+  'text-to-image-schnell': {
+    endpoint: FAL_ENDPOINTS.FLUX_SCHNELL,
+    buildInput: (input) => ({
+      prompt: input.prompt,
+      seed: input.seed,
+      sync_mode: input.sync_mode,
+      num_images: input.num_images,
+      output_format: input.output_format,
+      image_size: aspectRatioToFalImageSize(input.aspect_ratio),
+      num_inference_steps: 4,
+    }),
+  },
+  'text-to-image-dev': {
+    endpoint: FAL_ENDPOINTS.FLUX_DEV,
+    buildInput: (input) => buildFalTextToImageInput(input),
+  },
+  'text-to-image-realism': {
+    endpoint: FAL_ENDPOINTS.FLUX_GENERAL,
+    buildInput: (input) => ({
+      ...buildFalTextToImageInput(input),
+      loras: [
+        {
+          path: 'https://huggingface.co/XLabs-AI/flux-RealismLora/resolve/main/lora.safetensors',
+          scale: 0.8,
+        },
+      ],
+    }),
+  },
+  'text-to-image-anime': {
+    endpoint: FAL_ENDPOINTS.FLUX_GENERAL,
+    buildInput: (input) => ({
+      ...buildFalTextToImageInput(input),
+      loras: [
+        {
+          path: 'https://huggingface.co/Shakker-Labs/FLUX.1-dev-LoRA-AnimeStyle/resolve/main/FLUX-dev-lora-AnimeStyle.safetensors',
+          scale: 0.9,
+        },
+      ],
+    }),
+  },
+  'edit-image-pro': {
+    endpoint: FAL_ENDPOINTS.KONTEXT_PRO,
+    buildInput: (input) => buildFalEditInput(assertSingleImageInput('edit-image-pro', input), input),
+  },
+  'edit-image-max': {
+    endpoint: FAL_ENDPOINTS.KONTEXT_MAX,
+    buildInput: (input) => buildFalEditInput(assertSingleImageInput('edit-image-max', input), input),
+  },
+  'edit-multi-image-pro': {
+    endpoint: FAL_ENDPOINTS.KONTEXT_PRO_MULTI,
+    buildInput: (input) =>
+      buildFalMultiImageInput(
+        assertMultiImageInput('edit-multi-image-pro', input),
+        input
+      ),
+  },
+  'edit-multi-image-max': {
+    endpoint: FAL_ENDPOINTS.KONTEXT_MAX_MULTI,
+    buildInput: (input) =>
+      buildFalMultiImageInput(
+        assertMultiImageInput('edit-multi-image-max', input),
+        input
+      ),
+  },
+}
+
+export class FalImageGenerationProvider implements FluxKontextProvider {
+  readonly name = 'fal' as const
+  readonly supportedActions = Object.keys(FAL_ACTIONS) as FluxKontextAction[]
+
+  async generate(
+    action: FluxKontextAction,
+    input: FluxKontextGenerationRequest
+  ): Promise<FluxKontextResult> {
+    const config = FAL_ACTIONS[action]
+    const result = await subscribeToFal(config.endpoint, {
+      input: config.buildInput(input),
+      logs: true,
+      onQueueUpdate: (update) => {
+        if (update.status === 'IN_PROGRESS') {
+          console.log(
+            `[fal] ${action} progress:`,
+            update.logs?.map((log) => log.message).join('\n')
+          )
+        }
+      },
+    })
+
+    const payload =
+      result && typeof result === 'object' && 'data' in result
+        ? ((result as { data?: Record<string, unknown> }).data ??
+            (result as Record<string, unknown>))
+        : (result as Record<string, unknown>)
+
+    return normalizeGenerationResult(this.name, payload)
+  }
+
+  async uploadFile(file: File): Promise<string> {
+    return uploadToFalStorage(file)
+  }
+
+  async submitTask(
+    action: FluxKontextAction,
+    input: FluxKontextGenerationRequest,
+    options?: { webhookUrl?: string }
+  ): Promise<FluxKontextTaskHandle> {
+    const config = FAL_ACTIONS[action]
+    const submission = await submitFalQueue(config.endpoint, {
+      input: config.buildInput(input),
+      webhookUrl: options?.webhookUrl,
+    })
+
+    return {
+      provider: this.name,
+      taskId: submission.request_id,
+      raw: submission,
+    }
+  }
+
+  async getTaskResult(
+    action: FluxKontextAction,
+    taskId: string
+  ): Promise<FluxKontextTaskResult> {
+    const config = FAL_ACTIONS[action]
+    const status = await getFalQueueStatus(config.endpoint, {
+      requestId: taskId,
+      logs: true,
+    })
+
+    const state = mapFalState(status.status)
+
+    if (state !== 'completed') {
+      return {
+        provider: this.name,
+        taskId,
+        state,
+        raw: status,
+      }
+    }
+
+    const result = await getFalQueueResult(config.endpoint, {
+      requestId: taskId,
+    })
+
+    const payload =
+      result && typeof result === 'object' && 'data' in result
+        ? ((result as { data?: Record<string, unknown> }).data ??
+            (result as Record<string, unknown>))
+        : (result as Record<string, unknown>)
+
+    return {
+      provider: this.name,
+      taskId,
+      state: 'completed',
+      result: normalizeGenerationResult(this.name, payload),
+      raw: result,
+    }
+  }
+}
+
+function buildFalTextToImageInput(input: FluxKontextGenerationRequest) {
+  return {
+    prompt: input.prompt,
+    seed: input.seed,
+    guidance_scale: input.guidance_scale,
+    sync_mode: input.sync_mode,
+    num_images: input.num_images,
+    safety_tolerance: input.safety_tolerance,
+    output_format: input.output_format,
+    image_size: aspectRatioToFalImageSize(input.aspect_ratio),
+  }
+}
+
+function buildFalEditInput(
+  imageUrl: string,
+  input: FluxKontextGenerationRequest
+) {
+  return {
+    prompt: input.prompt,
+    image_url: imageUrl,
+    seed: input.seed,
+    guidance_scale: input.guidance_scale,
+    num_images: input.num_images,
+    safety_tolerance: input.safety_tolerance,
+    output_format: input.output_format,
+  }
+}
+
+function buildFalMultiImageInput(
+  imageUrls: string[],
+  input: FluxKontextGenerationRequest
+) {
+  return {
+    prompt: input.prompt,
+    image_urls: imageUrls,
+    seed: input.seed,
+    guidance_scale: input.guidance_scale,
+    num_images: input.num_images,
+    safety_tolerance: input.safety_tolerance,
+    output_format: input.output_format,
+  }
+}
+
+function mapFalState(status?: string): FluxKontextTaskState {
+  switch (status) {
+    case 'COMPLETED':
+      return 'completed'
+    case 'IN_PROGRESS':
+      return 'processing'
+    case 'FAILED':
+      return 'failed'
+    case 'IN_QUEUE':
+    default:
+      return 'queued'
+  }
+}

--- a/src/lib/image-generation/providers/index.ts
+++ b/src/lib/image-generation/providers/index.ts
@@ -1,0 +1,25 @@
+import { FalImageGenerationProvider } from '@/lib/image-generation/providers/fal-provider'
+import { KieImageGenerationProvider } from '@/lib/image-generation/providers/kie-provider'
+import { WaveSpeedImageGenerationProvider } from '@/lib/image-generation/providers/wavespeed-provider'
+import {
+  FluxKontextProvider,
+  ImageGenerationProviderName,
+} from '@/lib/image-generation/types'
+import { getConfiguredImageProvider } from '@/lib/image-generation/utils'
+
+const providerRegistry: Record<ImageGenerationProviderName, FluxKontextProvider> =
+  {
+    fal: new FalImageGenerationProvider(),
+    kie: new KieImageGenerationProvider(),
+    wavespeed: new WaveSpeedImageGenerationProvider(),
+  }
+
+export function getImageGenerationProvider(
+  providerName: ImageGenerationProviderName = getConfiguredImageProvider()
+): FluxKontextProvider {
+  return providerRegistry[providerName]
+}
+
+export function getImageGenerationProviderName(): ImageGenerationProviderName {
+  return getConfiguredImageProvider()
+}

--- a/src/lib/image-generation/providers/kie-provider.ts
+++ b/src/lib/image-generation/providers/kie-provider.ts
@@ -1,0 +1,302 @@
+import { createHmac, timingSafeEqual } from 'node:crypto'
+
+import {
+  FluxKontextAction,
+  FluxKontextGenerationRequest,
+  FluxKontextProvider,
+  FluxKontextResult,
+  FluxKontextTaskHandle,
+  FluxKontextTaskResult,
+  FluxKontextTaskState,
+} from '@/lib/image-generation/types'
+import {
+  assertSingleImageInput,
+  getHeader,
+  normalizeGenerationResult,
+  sleep,
+} from '@/lib/image-generation/utils'
+
+const KIE_BASE_URL = process.env.KIE_API_BASE_URL?.trim() || 'https://api.kie.ai'
+const KIE_POLL_INTERVAL_MS = Number(process.env.KIE_POLL_INTERVAL_MS || 2000)
+const KIE_POLL_TIMEOUT_MS = Number(process.env.KIE_POLL_TIMEOUT_MS || 50000)
+
+const KIE_ACTIONS: Record<
+  SupportedKieAction,
+  {
+    model: 'flux-kontext-pro' | 'flux-kontext-max'
+    requiresImage: boolean
+  }
+> = {
+  'text-to-image-pro': { model: 'flux-kontext-pro', requiresImage: false },
+  'text-to-image-max': { model: 'flux-kontext-max', requiresImage: false },
+  'edit-image-pro': { model: 'flux-kontext-pro', requiresImage: true },
+  'edit-image-max': { model: 'flux-kontext-max', requiresImage: true },
+}
+
+type SupportedKieAction =
+  | 'text-to-image-pro'
+  | 'text-to-image-max'
+  | 'edit-image-pro'
+  | 'edit-image-max'
+
+type KieGenerateResponse = {
+  taskId?: string
+  code?: number
+  message?: string
+  data?: {
+    taskId?: string
+  }
+}
+
+type KieRecordResponse = {
+  code?: number
+  message?: string
+  data?: Record<string, unknown>
+  resultImageUrl?: string
+  successFlag?: number
+}
+
+export class KieImageGenerationProvider implements FluxKontextProvider {
+  readonly name = 'kie' as const
+  readonly supportedActions = Object.keys(KIE_ACTIONS) as SupportedKieAction[]
+
+  async generate(
+    action: FluxKontextAction,
+    input: FluxKontextGenerationRequest
+  ): Promise<FluxKontextResult> {
+    const handle = await this.submitTask(action, input)
+    const startedAt = Date.now()
+
+    while (Date.now() - startedAt < KIE_POLL_TIMEOUT_MS) {
+      const task = await this.getTaskResult(action, handle.taskId)
+
+      if (task.state === 'completed' && task.result) {
+        return task.result
+      }
+
+      if (task.state === 'failed') {
+        throw new Error(task.error || 'KIE task failed')
+      }
+
+      await sleep(KIE_POLL_INTERVAL_MS)
+    }
+
+    throw new Error('KIE request timed out before a result was available')
+  }
+
+  async submitTask(
+    action: FluxKontextAction,
+    input: FluxKontextGenerationRequest,
+    options?: { webhookUrl?: string }
+  ): Promise<FluxKontextTaskHandle> {
+    const config = getKieAction(action)
+    const response = await postKie<KieGenerateResponse>(
+      '/api/v1/flux/kontext/generate',
+      {
+        prompt: input.prompt,
+        model: config.model,
+        image_url: config.requiresImage
+          ? assertSingleImageInput(action, input)
+          : undefined,
+        aspect_ratio: input.aspect_ratio,
+        aspectRatio: input.aspect_ratio,
+        guidance_scale: input.guidance_scale,
+        guidanceScale: input.guidance_scale,
+        num_images: input.num_images,
+        numImages: input.num_images,
+        seed: input.seed,
+        output_format: input.output_format,
+        outputFormat: input.output_format,
+        safety_tolerance: input.safety_tolerance,
+        safetyTolerance: input.safety_tolerance,
+        callBackUrl: options?.webhookUrl,
+      }
+    )
+
+    const taskId = response.taskId || response.data?.taskId
+
+    if (!taskId) {
+      throw new Error('KIE did not return a taskId')
+    }
+
+    return {
+      provider: this.name,
+      taskId,
+      raw: response,
+    }
+  }
+
+  async getTaskResult(
+    action: FluxKontextAction,
+    taskId: string
+  ): Promise<FluxKontextTaskResult> {
+    getKieAction(action)
+
+    const response = await getKie<KieRecordResponse>(
+      `/api/v1/flux/kontext/record-info?taskId=${encodeURIComponent(taskId)}`
+    )
+
+    const normalized = normalizeKiePayload(response)
+
+    return {
+      provider: this.name,
+      taskId,
+      state: normalized.state,
+      result: normalized.result,
+      error: normalized.error,
+      raw: response,
+    }
+  }
+
+  async verifyWebhook(
+    rawBody: string,
+    headers: Headers | Record<string, string | undefined>
+  ): Promise<boolean> {
+    const secret = process.env.KIE_WEBHOOK_SIGNING_SECRET?.trim()
+
+    if (!secret) {
+      return false
+    }
+
+    const signature =
+      getHeader(headers, 'x-kie-signature') || getHeader(headers, 'x-signature')
+    const timestamp =
+      getHeader(headers, 'x-kie-timestamp') || getHeader(headers, 'x-timestamp')
+
+    if (!signature || !timestamp) {
+      return false
+    }
+
+    let taskId = ''
+
+    try {
+      const parsed = JSON.parse(rawBody) as { taskId?: string; data?: { taskId?: string } }
+      taskId = parsed.taskId || parsed.data?.taskId || ''
+    } catch {
+      return false
+    }
+
+    if (!taskId) {
+      return false
+    }
+
+    const payload = `${taskId}.${timestamp}`
+    const expected = createHmac('sha256', secret).update(payload).digest('base64')
+
+    return safeEqual(expected, signature)
+  }
+}
+
+function getKieAction(action: FluxKontextAction) {
+  const config = KIE_ACTIONS[action as SupportedKieAction]
+
+  if (!config) {
+    throw new Error(`KIE provider does not support ${action}`)
+  }
+
+  return config
+}
+
+function getKieApiKey() {
+  const key = process.env.KIE_API_KEY?.trim()
+
+  if (!key) {
+    throw new Error('KIE_API_KEY is required when IMAGE_GENERATION_PROVIDER=kie')
+  }
+
+  return key
+}
+
+async function postKie<T>(path: string, body: Record<string, unknown>) {
+  const response = await fetch(`${KIE_BASE_URL}${path}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${getKieApiKey()}`,
+    },
+    body: JSON.stringify(
+      Object.fromEntries(
+        Object.entries(body).filter(([, value]) => typeof value !== 'undefined')
+      )
+    ),
+  })
+
+  const json = (await response.json()) as T & { message?: string }
+
+  if (!response.ok) {
+    throw new Error(json.message || `KIE request failed with ${response.status}`)
+  }
+
+  return json
+}
+
+async function getKie<T>(path: string) {
+  const response = await fetch(`${KIE_BASE_URL}${path}`, {
+    headers: {
+      Authorization: `Bearer ${getKieApiKey()}`,
+    },
+  })
+
+  const json = (await response.json()) as T & { message?: string }
+
+  if (!response.ok) {
+    throw new Error(json.message || `KIE request failed with ${response.status}`)
+  }
+
+  return json
+}
+
+function normalizeKiePayload(response: KieRecordResponse): {
+  state: FluxKontextTaskState
+  result?: FluxKontextResult
+  error?: string
+} {
+  const data = response.data ?? {}
+  const successFlag =
+    typeof response.successFlag === 'number'
+      ? response.successFlag
+      : typeof data.successFlag === 'number'
+        ? (data.successFlag as number)
+        : 0
+
+  if (successFlag === 0) {
+    return { state: 'processing' }
+  }
+
+  if (successFlag !== 1) {
+    return {
+      state: 'failed',
+      error:
+        (data.errorMessage as string | undefined) ||
+        response.message ||
+        'KIE task failed',
+    }
+  }
+
+  const imageUrl =
+    (data.resultImageUrl as string | undefined) ||
+    (response.resultImageUrl as string | undefined)
+
+  const payload: Record<string, unknown> = imageUrl
+    ? {
+        ...data,
+        images: [{ url: imageUrl }],
+      }
+    : data
+
+  return {
+    state: 'completed',
+    result: normalizeGenerationResult('kie', payload),
+  }
+}
+
+function safeEqual(left: string, right: string) {
+  const leftBuffer = Buffer.from(left)
+  const rightBuffer = Buffer.from(right)
+
+  if (leftBuffer.length !== rightBuffer.length) {
+    return false
+  }
+
+  return timingSafeEqual(leftBuffer, rightBuffer)
+}

--- a/src/lib/image-generation/providers/wavespeed-provider.ts
+++ b/src/lib/image-generation/providers/wavespeed-provider.ts
@@ -1,0 +1,368 @@
+import { createHmac, timingSafeEqual } from 'node:crypto'
+
+import {
+  FluxKontextAction,
+  FluxKontextGenerationRequest,
+  FluxKontextProvider,
+  FluxKontextResult,
+  FluxKontextTaskHandle,
+  FluxKontextTaskResult,
+  FluxKontextTaskState,
+} from '@/lib/image-generation/types'
+import {
+  assertMultiImageInput,
+  assertSingleImageInput,
+  getHeader,
+  normalizeGenerationResult,
+  sleep,
+} from '@/lib/image-generation/utils'
+
+const WAVESPEED_BASE_URL =
+  process.env.WAVESPEED_API_BASE_URL?.trim() || 'https://api.wavespeed.ai/api/v3'
+const WAVESPEED_POLL_INTERVAL_MS = Number(
+  process.env.WAVESPEED_POLL_INTERVAL_MS || 2000
+)
+const WAVESPEED_POLL_TIMEOUT_MS = Number(
+  process.env.WAVESPEED_POLL_TIMEOUT_MS || 50000
+)
+
+const WAVESPEED_ACTIONS: Record<
+  SupportedWaveSpeedAction,
+  {
+    endpoint: string
+    buildInput: (
+      input: FluxKontextGenerationRequest
+    ) => Record<string, unknown>
+  }
+> = {
+  'text-to-image-pro': {
+    endpoint: 'wavespeed-ai/flux-kontext-pro/text-to-image',
+    buildInput: (input) => buildWaveSpeedTextInput(input),
+  },
+  'text-to-image-max': {
+    endpoint: 'wavespeed-ai/flux-kontext-max/text-to-image',
+    buildInput: (input) => buildWaveSpeedTextInput(input),
+  },
+  'edit-image-pro': {
+    endpoint: 'wavespeed-ai/flux-kontext-pro',
+    buildInput: (input) => ({
+      ...buildWaveSpeedBaseInput(input),
+      image: assertSingleImageInput('edit-image-pro', input),
+    }),
+  },
+  'edit-image-max': {
+    endpoint: 'wavespeed-ai/flux-kontext-max',
+    buildInput: (input) => ({
+      ...buildWaveSpeedBaseInput(input),
+      image: assertSingleImageInput('edit-image-max', input),
+    }),
+  },
+  'edit-multi-image-pro': {
+    endpoint: 'wavespeed-ai/flux-kontext-pro/multi',
+    buildInput: (input) => ({
+      ...buildWaveSpeedBaseInput(input),
+      images: assertMultiImageInput('edit-multi-image-pro', input),
+    }),
+  },
+  'edit-multi-image-max': {
+    endpoint: 'wavespeed-ai/flux-kontext-max/multi',
+    buildInput: (input) => ({
+      ...buildWaveSpeedBaseInput(input),
+      images: assertMultiImageInput('edit-multi-image-max', input),
+    }),
+  },
+}
+
+type SupportedWaveSpeedAction =
+  | 'text-to-image-pro'
+  | 'text-to-image-max'
+  | 'edit-image-pro'
+  | 'edit-image-max'
+  | 'edit-multi-image-pro'
+  | 'edit-multi-image-max'
+
+type WaveSpeedPrediction = {
+  code?: number
+  message?: string
+  data?: {
+    id?: string
+    model?: string
+    outputs?: string[]
+    status?: string
+    error?: string
+    timings?: Record<string, unknown>
+    has_nsfw_contents?: boolean[]
+  }
+}
+
+export class WaveSpeedImageGenerationProvider implements FluxKontextProvider {
+  readonly name = 'wavespeed' as const
+  readonly supportedActions = Object.keys(
+    WAVESPEED_ACTIONS
+  ) as SupportedWaveSpeedAction[]
+
+  async generate(
+    action: FluxKontextAction,
+    input: FluxKontextGenerationRequest
+  ): Promise<FluxKontextResult> {
+    const config = getWaveSpeedAction(action)
+    const response = await postWaveSpeed(config.endpoint, {
+      ...config.buildInput(input),
+      enable_sync_mode: true,
+    })
+
+    const normalized = normalizeWaveSpeedTask(response)
+
+    if (normalized.state === 'completed' && normalized.result) {
+      return normalized.result
+    }
+
+    if (!response.data?.id) {
+      throw new Error('WaveSpeed did not return a prediction id')
+    }
+
+    const startedAt = Date.now()
+
+    while (Date.now() - startedAt < WAVESPEED_POLL_TIMEOUT_MS) {
+      const task = await this.getTaskResult(action, response.data.id)
+
+      if (task.state === 'completed' && task.result) {
+        return task.result
+      }
+
+      if (task.state === 'failed') {
+        throw new Error(task.error || 'WaveSpeed task failed')
+      }
+
+      await sleep(WAVESPEED_POLL_INTERVAL_MS)
+    }
+
+    throw new Error('WaveSpeed request timed out before a result was available')
+  }
+
+  async submitTask(
+    action: FluxKontextAction,
+    input: FluxKontextGenerationRequest,
+    options?: { webhookUrl?: string }
+  ): Promise<FluxKontextTaskHandle> {
+    const config = getWaveSpeedAction(action)
+    const response = await postWaveSpeed(config.endpoint, {
+      ...config.buildInput(input),
+      webhook_url: options?.webhookUrl,
+    })
+
+    const taskId = response.data?.id
+
+    if (!taskId) {
+      throw new Error('WaveSpeed did not return a prediction id')
+    }
+
+    return {
+      provider: this.name,
+      taskId,
+      raw: response,
+    }
+  }
+
+  async getTaskResult(
+    action: FluxKontextAction,
+    taskId: string
+  ): Promise<FluxKontextTaskResult> {
+    getWaveSpeedAction(action)
+    const response = await getWaveSpeed(`/predictions/${taskId}/result`)
+    const normalized = normalizeWaveSpeedTask(response)
+
+    return {
+      provider: this.name,
+      taskId,
+      state: normalized.state,
+      result: normalized.result,
+      error: normalized.error,
+      raw: response,
+    }
+  }
+
+  async verifyWebhook(
+    rawBody: string,
+    headers: Headers | Record<string, string | undefined>
+  ): Promise<boolean> {
+    const secret = normalizeWebhookSecret(
+      process.env.WAVESPEED_WEBHOOK_SECRET?.trim()
+    )
+
+    if (!secret) {
+      return false
+    }
+
+    const webhookId = getHeader(headers, 'webhook-id')
+    const timestamp = getHeader(headers, 'webhook-timestamp')
+    const signatureHeader = getHeader(headers, 'webhook-signature')
+
+    if (!webhookId || !timestamp || !signatureHeader) {
+      return false
+    }
+
+    const timestampNumber = Number(timestamp)
+
+    if (!Number.isFinite(timestampNumber)) {
+      return false
+    }
+
+    if (Math.abs(Date.now() / 1000 - timestampNumber) > 300) {
+      return false
+    }
+
+    const payload = `${webhookId}.${timestamp}.${rawBody}`
+    const expected = createHmac('sha256', secret).update(payload).digest('hex')
+
+    return extractWaveSpeedSignatures(signatureHeader).some((signature) =>
+      safeEqual(expected, signature)
+    )
+  }
+}
+
+function getWaveSpeedAction(action: FluxKontextAction) {
+  const config = WAVESPEED_ACTIONS[action as SupportedWaveSpeedAction]
+
+  if (!config) {
+    throw new Error(`WaveSpeed provider does not support ${action}`)
+  }
+
+  return config
+}
+
+function getWaveSpeedApiKey() {
+  const key = process.env.WAVESPEED_API_KEY?.trim()
+
+  if (!key) {
+    throw new Error(
+      'WAVESPEED_API_KEY is required when IMAGE_GENERATION_PROVIDER=wavespeed'
+    )
+  }
+
+  return key
+}
+
+async function postWaveSpeed(
+  endpoint: string,
+  body: Record<string, unknown>
+): Promise<WaveSpeedPrediction> {
+  const apiKey = getWaveSpeedApiKey()
+  const response = await fetch(`${WAVESPEED_BASE_URL}/${endpoint}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+      'x-api-key': apiKey,
+    },
+    body: JSON.stringify(
+      Object.fromEntries(
+        Object.entries(body).filter(([, value]) => typeof value !== 'undefined')
+      )
+    ),
+  })
+
+  const json = (await response.json()) as WaveSpeedPrediction
+
+  if (!response.ok) {
+    throw new Error(json.message || `WaveSpeed request failed with ${response.status}`)
+  }
+
+  return json
+}
+
+async function getWaveSpeed(path: string): Promise<WaveSpeedPrediction> {
+  const apiKey = getWaveSpeedApiKey()
+  const response = await fetch(`${WAVESPEED_BASE_URL}${path}`, {
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'x-api-key': apiKey,
+    },
+  })
+
+  const json = (await response.json()) as WaveSpeedPrediction
+
+  if (!response.ok) {
+    throw new Error(json.message || `WaveSpeed request failed with ${response.status}`)
+  }
+
+  return json
+}
+
+function buildWaveSpeedBaseInput(input: FluxKontextGenerationRequest) {
+  return {
+    prompt: input.prompt,
+    aspect_ratio: input.aspect_ratio,
+    seed: input.seed,
+    num_images: input.num_images,
+    guidance_scale: input.guidance_scale,
+    output_format: input.output_format,
+    safety_tolerance: input.safety_tolerance,
+  }
+}
+
+function buildWaveSpeedTextInput(input: FluxKontextGenerationRequest) {
+  return buildWaveSpeedBaseInput(input)
+}
+
+function normalizeWaveSpeedTask(response: WaveSpeedPrediction): {
+  state: FluxKontextTaskState
+  result?: FluxKontextResult
+  error?: string
+} {
+  const status = response.data?.status || 'created'
+
+  if (status === 'failed') {
+    return {
+      state: 'failed',
+      error: response.data?.error || response.message || 'WaveSpeed task failed',
+    }
+  }
+
+  if (status !== 'completed') {
+    return {
+      state: status === 'processing' ? 'processing' : 'queued',
+    }
+  }
+
+  const payload: Record<string, unknown> = {
+    images: response.data?.outputs?.map((url) => ({ url })) || [],
+    timings: response.data?.timings,
+    has_nsfw_concepts: response.data?.has_nsfw_contents,
+  }
+
+  return {
+    state: 'completed',
+    result: normalizeGenerationResult('wavespeed', payload),
+  }
+}
+
+function normalizeWebhookSecret(secret?: string) {
+  if (!secret) {
+    return ''
+  }
+
+  return secret.startsWith('whsec_') ? secret.slice(6) : secret
+}
+
+function extractWaveSpeedSignatures(signatureHeader: string) {
+  return signatureHeader
+    .split(/\s+/)
+    .flatMap((part) => part.split(','))
+    .map((part) => {
+      const [, value] = part.split('=')
+      return (value || part).trim()
+    })
+    .filter(Boolean)
+}
+
+function safeEqual(left: string, right: string) {
+  const leftBuffer = Buffer.from(left)
+  const rightBuffer = Buffer.from(right)
+
+  if (leftBuffer.length !== rightBuffer.length) {
+    return false
+  }
+
+  return timingSafeEqual(leftBuffer, rightBuffer)
+}

--- a/src/lib/image-generation/types.ts
+++ b/src/lib/image-generation/types.ts
@@ -1,0 +1,127 @@
+export const FLUX_KONTEXT_ACTIONS = [
+  'text-to-image-pro',
+  'text-to-image-max',
+  'text-to-image-schnell',
+  'text-to-image-dev',
+  'text-to-image-realism',
+  'text-to-image-anime',
+  'edit-image-pro',
+  'edit-image-max',
+  'edit-multi-image-pro',
+  'edit-multi-image-max',
+] as const
+
+export type FluxKontextAction = (typeof FLUX_KONTEXT_ACTIONS)[number]
+
+export type FluxKontextAspectRatio =
+  | '21:9'
+  | '16:9'
+  | '4:3'
+  | '3:2'
+  | '1:1'
+  | '2:3'
+  | '3:4'
+  | '9:16'
+  | '9:21'
+
+export type FluxKontextSafetyTolerance = '1' | '2' | '3' | '4' | '5' | '6'
+export type FluxKontextOutputFormat = 'jpeg' | 'png'
+
+export interface FluxKontextBaseInput {
+  prompt: string
+  seed?: number
+  guidance_scale?: number
+  sync_mode?: boolean
+  num_images?: number
+  safety_tolerance?: FluxKontextSafetyTolerance
+  output_format?: FluxKontextOutputFormat
+}
+
+export interface FluxKontextImageEditInput extends FluxKontextBaseInput {
+  image_url: string
+  aspect_ratio?: FluxKontextAspectRatio
+}
+
+export interface FluxKontextMultiImageInput extends FluxKontextBaseInput {
+  image_urls: string[]
+  aspect_ratio?: FluxKontextAspectRatio
+}
+
+export interface FluxKontextTextToImageInput extends FluxKontextBaseInput {
+  aspect_ratio?: FluxKontextAspectRatio
+}
+
+export interface FluxKontextGenerationRequest extends FluxKontextBaseInput {
+  action?: FluxKontextAction
+  image_url?: string
+  image_urls?: string[]
+  aspect_ratio?: FluxKontextAspectRatio
+  turnstile_token?: string
+}
+
+export interface FluxKontextImage {
+  url: string
+  width?: number
+  height?: number
+  content_type?: string
+  [key: string]: unknown
+}
+
+export interface FluxKontextResult {
+  images: FluxKontextImage[]
+  timings?: unknown
+  seed?: number
+  has_nsfw_concepts?: boolean[]
+  prompt?: string
+  provider?: ImageGenerationProviderName
+  raw?: unknown
+}
+
+export type ImageGenerationProviderName = 'fal' | 'kie' | 'wavespeed'
+export type FluxKontextTaskState =
+  | 'queued'
+  | 'processing'
+  | 'completed'
+  | 'failed'
+
+export interface FluxKontextTaskHandle {
+  provider: ImageGenerationProviderName
+  taskId: string
+  raw?: unknown
+}
+
+export interface FluxKontextTaskResult {
+  provider: ImageGenerationProviderName
+  taskId: string
+  state: FluxKontextTaskState
+  result?: FluxKontextResult
+  error?: string
+  raw?: unknown
+}
+
+export interface FluxKontextSubmitTaskOptions {
+  webhookUrl?: string
+}
+
+export interface FluxKontextProvider {
+  readonly name: ImageGenerationProviderName
+  readonly supportedActions: readonly FluxKontextAction[]
+  generate(
+    action: FluxKontextAction,
+    input: FluxKontextGenerationRequest
+  ): Promise<FluxKontextResult>
+  uploadFile?(file: File): Promise<string>
+  submitTask?(
+    action: FluxKontextAction,
+    input: FluxKontextGenerationRequest,
+    options?: FluxKontextSubmitTaskOptions
+  ): Promise<FluxKontextTaskHandle>
+  getTaskResult?(
+    action: FluxKontextAction,
+    taskId: string
+  ): Promise<FluxKontextTaskResult>
+  verifyWebhook?(
+    rawBody: string,
+    headers: Headers | Record<string, string | undefined>
+  ): Promise<boolean>
+}

--- a/src/lib/image-generation/utils.ts
+++ b/src/lib/image-generation/utils.ts
@@ -1,0 +1,234 @@
+import {
+  FLUX_KONTEXT_ACTIONS,
+  FluxKontextAction,
+  FluxKontextAspectRatio,
+  FluxKontextGenerationRequest,
+  FluxKontextImage,
+  FluxKontextResult,
+  ImageGenerationProviderName,
+} from '@/lib/image-generation/types'
+
+const VALID_PROVIDERS: ImageGenerationProviderName[] = [
+  'fal',
+  'kie',
+  'wavespeed',
+]
+
+let invalidProviderWarned = false
+
+export function isFluxKontextAction(value: string): value is FluxKontextAction {
+  return (FLUX_KONTEXT_ACTIONS as readonly string[]).includes(value)
+}
+
+export function getConfiguredImageProvider(): ImageGenerationProviderName {
+  const configured = process.env.IMAGE_GENERATION_PROVIDER?.trim().toLowerCase()
+
+  if (!configured) {
+    return 'fal'
+  }
+
+  if (VALID_PROVIDERS.includes(configured as ImageGenerationProviderName)) {
+    return configured as ImageGenerationProviderName
+  }
+
+  if (!invalidProviderWarned) {
+    invalidProviderWarned = true
+    console.warn(
+      `Unsupported IMAGE_GENERATION_PROVIDER "${configured}", falling back to fal.`
+    )
+  }
+
+  return 'fal'
+}
+
+export function assertSingleImageInput(
+  action: FluxKontextAction,
+  input: FluxKontextGenerationRequest
+): string {
+  if (!input.image_url) {
+    throw new Error(`image_url is required for ${action}`)
+  }
+
+  return input.image_url
+}
+
+export function assertMultiImageInput(
+  action: FluxKontextAction,
+  input: FluxKontextGenerationRequest
+): string[] {
+  if (!input.image_urls?.length) {
+    throw new Error(`image_urls is required for ${action}`)
+  }
+
+  return input.image_urls
+}
+
+export function aspectRatioToFalImageSize(
+  aspectRatio?: FluxKontextAspectRatio
+):
+  | 'square_hd'
+  | 'square'
+  | 'portrait_4_3'
+  | 'portrait_16_9'
+  | 'landscape_4_3'
+  | 'landscape_16_9' {
+  switch (aspectRatio) {
+    case '1:1':
+      return 'square_hd'
+    case '3:4':
+    case '2:3':
+      return 'portrait_4_3'
+    case '9:16':
+    case '9:21':
+      return 'portrait_16_9'
+    case '16:9':
+    case '21:9':
+      return 'landscape_16_9'
+    case '4:3':
+    case '3:2':
+    default:
+      return 'landscape_4_3'
+  }
+}
+
+export function firstNonEmptyImageList(
+  payload: Record<string, unknown> | null | undefined
+): FluxKontextImage[] | null {
+  if (!payload) {
+    return null
+  }
+
+  const candidates = ['images', 'data.images', 'output', 'outputs', 'result']
+
+  for (const candidate of candidates) {
+    const value = readPath(payload, candidate)
+
+    if (Array.isArray(value) && value.length > 0) {
+      return normalizeImages(value)
+    }
+
+    if (typeof value === 'string' && value.startsWith('http')) {
+      return [{ url: value }]
+    }
+
+    if (
+      value &&
+      typeof value === 'object' &&
+      typeof (value as { url?: unknown }).url === 'string'
+    ) {
+      return [{ ...(value as FluxKontextImage) }]
+    }
+  }
+
+  return null
+}
+
+export function normalizeGenerationResult(
+  provider: ImageGenerationProviderName,
+  payload: Record<string, unknown> | null | undefined
+): FluxKontextResult {
+  const images = firstNonEmptyImageList(payload)
+
+  if (!images?.length) {
+    throw new Error(`No images were returned by the ${provider} provider`)
+  }
+
+  return {
+    images,
+    prompt: readOptionalString(payload, 'prompt'),
+    seed: readOptionalNumber(payload, 'seed'),
+    timings: readPath(payload, 'timings'),
+    has_nsfw_concepts: readBooleanArray(payload, 'has_nsfw_concepts'),
+    provider,
+    raw: payload,
+  }
+}
+
+export function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+export function getHeader(
+  headers: Headers | Record<string, string | undefined>,
+  name: string
+): string | undefined {
+  if (headers instanceof Headers) {
+    return headers.get(name) ?? undefined
+  }
+
+  const lowered = name.toLowerCase()
+
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() === lowered) {
+      return value
+    }
+  }
+
+  return undefined
+}
+
+function normalizeImages(images: unknown[]): FluxKontextImage[] {
+  return images
+    .map((image) => {
+      if (typeof image === 'string' && image.startsWith('http')) {
+        return { url: image }
+      }
+
+      if (
+        image &&
+        typeof image === 'object' &&
+        typeof (image as { url?: unknown }).url === 'string'
+      ) {
+        return image as FluxKontextImage
+      }
+
+      return null
+    })
+    .filter((image): image is FluxKontextImage => !!image)
+}
+
+function readPath(
+  payload: Record<string, unknown> | null | undefined,
+  path: string
+): unknown {
+  if (!payload) {
+    return undefined
+  }
+
+  return path.split('.').reduce<unknown>((current, key) => {
+    if (!current || typeof current !== 'object') {
+      return undefined
+    }
+
+    return (current as Record<string, unknown>)[key]
+  }, payload)
+}
+
+function readOptionalString(
+  payload: Record<string, unknown> | null | undefined,
+  path: string
+): string | undefined {
+  const value = readPath(payload, path)
+  return typeof value === 'string' ? value : undefined
+}
+
+function readOptionalNumber(
+  payload: Record<string, unknown> | null | undefined,
+  path: string
+): number | undefined {
+  const value = readPath(payload, path)
+  return typeof value === 'number' ? value : undefined
+}
+
+function readBooleanArray(
+  payload: Record<string, unknown> | null | undefined,
+  path: string
+): boolean[] | undefined {
+  const value = readPath(payload, path)
+
+  if (!Array.isArray(value)) {
+    return undefined
+  }
+
+  return value.filter((item): item is boolean => typeof item === 'boolean')
+}


### PR DESCRIPTION
## Summary
- add a unified image-generation provider adapter layer for fal, KIE, and WaveSpeed
- slim down `src/lib/flux-kontext.ts` into a facade and route `/api/flux-kontext` through the provider layer
- keep the current frontend behavior unchanged while preparing multi-provider support behind server-side config

## Testing
- npm run lint
- npm run build
- localhost production smoke test on `http://127.0.0.1:3012`
- `curl -I /` -> 200
- `curl -I /generate` -> 200
- `curl /api/debug/env` -> 404
- unauthenticated `POST /api/flux-kontext` -> 401
- unauthenticated `PUT /api/flux-kontext` -> 401
