### PR TITLE
docs: note GitHub Actions re-enable for CodeQL rescan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning once tagged releases begin.
 - Upgrade the application from Next.js 15.5 / React 18 to Next.js 16.3 / React 19
 - Move request middleware to the Next.js 16 `proxy` convention
 - Raise Sharp to the 0.35 security line and pin patched PostCSS / brace-expansion versions
+- Re-enable GitHub Actions so CodeQL can rescan the default branch after the Next 16 merge
 
 ### Fixed
 


### PR DESCRIPTION
## Summary

- GitHub Actions was disabled, so the advanced CodeQL workflow never ran after #62
- Actions is now enabled; this docs-only change retriggers CodeQL on master so the two remaining code-scanning alerts can close

## Testing

- [x] Docs-only changelog note

## Risk

- [x] No new environment variables
- [x] No schema or data migration
- [x] No auth or payment behavior change